### PR TITLE
Fix git push typo

### DIFF
--- a/automation/publish.sh
+++ b/automation/publish.sh
@@ -85,7 +85,7 @@ git add .
 git commit --no-verify -m "Regenerate code from specification file"
 
 # Push
-git -c core.hooksPath=/dev/null checkout push --set-upstream origin $PR_BRANCH # disable git hooks https://stackoverflow.com/a/61485071
+git -c core.hooksPath=/dev/null push --set-upstream origin $PR_BRANCH # disable git hooks https://stackoverflow.com/a/61485071
 
 # ==============================
 # > CREATE A PR


### PR DESCRIPTION
This PR fixes an incorrect git push command in the generator:

https://github.com/algorand/generator/blob/master/automation/publish.sh#L88