### PR TITLE
Use format from array type if present & fix `PendingTransactionResponse` type

### DIFF
--- a/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -449,15 +449,18 @@ public class OpenApiParser {
 
         JsonNode paramNode = spec.get("parameters");
         String returnType = "String";
-        if (spec.has("responses") && spec.get("responses").has("200") &&
-                spec.get("responses").get("200").get("$ref") != null) {
-            returnType = spec.get("responses").get("200").get("$ref").asText();
-            JsonNode returnTypeNode = this.getFromRef(returnType);
-            if (returnTypeNode.get("schema").get("$ref") != null) {
-                returnType = OpenApiParser.getTypeNameFromRef(returnTypeNode.get("schema").get("$ref"));
-            } else {
-                returnType = OpenApiParser.getTypeNameFromRef(spec.get("responses").get("200").get("$ref"));
-                returnType = Tools.getCamelCase(returnType, true);
+        if (spec.has("responses") && spec.get("responses").has("200")) {
+            if (spec.get("responses").get("200").get("$ref") != null) {
+                returnType = spec.get("responses").get("200").get("$ref").asText();
+                JsonNode returnTypeNode = this.getFromRef(returnType);
+                if (returnTypeNode.get("schema").get("$ref") != null) {
+                    returnType = OpenApiParser.getTypeNameFromRef(returnTypeNode.get("schema").get("$ref"));
+                } else {
+                    returnType = OpenApiParser.getTypeNameFromRef(spec.get("responses").get("200").get("$ref"));
+                    returnType = Tools.getCamelCase(returnType, true);
+                }
+            } else if (spec.get("responses").get("200").has("schema") && spec.get("responses").get("200").get("schema").has("$ref")) {
+                returnType = OpenApiParser.getTypeNameFromRef(spec.get("responses").get("200").get("schema").get("$ref"));
             }
         }
         String desc = "";

--- a/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -138,6 +138,7 @@ public class OpenApiParser {
         String openApiAlgorandFormat = typeNode.has("x-algorand-format") ? typeNode.get("x-algorand-format").asText() : null;
         JsonNode arrayTypeNode = typeNode.get("items");
         String openApiArrayType = arrayTypeNode != null && arrayTypeNode.has("type") ? arrayTypeNode.get("type").asText() : null;
+        openApiFormat = openApiFormat == null && arrayTypeNode != null && arrayTypeNode.has("format") ? arrayTypeNode.get("format").asText() : openApiFormat;
 
         if (prop.get("enum") != null) {
             return getEnum(prop, propName, goName, openApiType, openApiArrayType, openApiFormat, openApiAlgorandFormat, goName);


### PR DESCRIPTION
This PR has 2 fixes:

1. Indexer's spec file uses `format` inside of the `items` property to describe an array item's format.

For example: https://github.com/algorand/indexer/blob/208ee4d7ecdbf1f240515311c3336b22c0c6339f/api/indexer.oas2.json#L1006-L1012

With the current generator code, this `format` property is missed. I made a small change to fix this, which I used to generate https://github.com/algorand/go-algorand-sdk/pull/248, but there may be a better way to do it.

2. Fix the response type for `/v2/transactions/pending/{txid}`. This was incorrectly being returned as `String` since the recent changes to the pending transaction endpoint response type: https://github.com/algorand/go-algorand/blob/e40b7ef31798976cceeee5bb2a7ac77474129174/daemon/algod/api/algod.oas2.json#L813-L817