### PR TITLE
Initialize list of bytes in Java

### DIFF
--- a/src/main/java/com/algorand/sdkutils/listeners/JavaGenerator.java
+++ b/src/main/java/com/algorand/sdkutils/listeners/JavaGenerator.java
@@ -953,7 +953,7 @@ final class JavaModelWriter {
                 "         }\n" +
                 "         return ret; \n" +
                 "     }\n" +
-                "    public List<byte[]> " + javaName + ";\n");
+                "    public List<byte[]> " + javaName + " = new ArrayList<byte[]>();\n");
     }
 
     // Get base64 encoded byte[] type.


### PR DESCRIPTION
There is a new optional `logs` field present on a few models, and without this the getter method throws an NPE, since it tries to iterate over a null List.