### PR TITLE
Handle definitions where the top level object is an array.

### DIFF
--- a/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -344,10 +344,21 @@ public class OpenApiParser {
         }
 
         List<TypeDef> properties = new ArrayList<>();
-        for (Map.Entry<String, JsonNode> prop : getSortedProperties(propertiesNode).entrySet()) {
-            String jprop = prop.getKey();
-            TypeDef typeObj = getType(prop.getValue(), true, jprop, true, requiredProperties.contains(jprop));
+
+        // type: object
+        if (propertiesNode != null) {
+            for (Map.Entry<String, JsonNode> prop : getSortedProperties(propertiesNode).entrySet()) {
+                String jprop = prop.getKey();
+                TypeDef typeObj = getType(prop.getValue(), true, jprop, true, requiredProperties.contains(jprop));
+                properties.add(typeObj);
+            }
+        }
+        // type: array
+        else if (parentNode.has("schema") && parentNode.get("schema").has("type") && parentNode.get("schema").get("type").asText().equals("array")) {
+            TypeDef typeObj = getType(parentNode.get("schema"), true, "", true, false);
             properties.add(typeObj);
+        } else {
+            throw new RuntimeException("Unexpected type.");
         }
 
         publisher.publish(event, new StructDef(className, desc, properties, requiredProperties, mutuallyExclusiveProperties));


### PR DESCRIPTION
The parser was failing on types where the top-level type is an "array". It was assumed (and previously true) that the top-level object was always an "object".

This is the type that detected this condition:
```
    "ParticipationKeysResponse": {
      "description": "A list of participation keys",
      "schema": {          
        "type": "array",
        "items": {
          "$ref": "#/definitions/ParticipationKey"      
        }         
      }              
    },
```

I tested by stepping into the code and was able to see that this type was correctly converted into `List<ParticipationKey>`.