### PR TITLE
Add support for recursive oas files in response generator

### DIFF
--- a/src/main/java/com/algorand/sdkutils/listeners/ResponseGenerator.java
+++ b/src/main/java/com/algorand/sdkutils/listeners/ResponseGenerator.java
@@ -211,7 +211,8 @@ public class ResponseGenerator implements Subscriber {
         List<ObjectNode> nodes = new ArrayList<>();
         nodes.add(mapper.createObjectNode());
         for (TypeDef prop : properties) {
-            // Skip properties in the exclusion list or that have already been visited.
+            // Skip properties in the exclusion list or that have already been visited
+            // twice.
             if (!exclusions.contains(prop.propertyName) &&
                     (enteredTypes.getOrDefault(prop.rawTypeName, 0) <= 1)) {
                 List<JsonNode> propertyNodes = new ArrayList<>();

--- a/src/main/java/com/algorand/sdkutils/listeners/ResponseGenerator.java
+++ b/src/main/java/com/algorand/sdkutils/listeners/ResponseGenerator.java
@@ -211,7 +211,7 @@ public class ResponseGenerator implements Subscriber {
         List<ObjectNode> nodes = new ArrayList<>();
         nodes.add(mapper.createObjectNode());
         for (TypeDef prop : properties) {
-            // Skip properties in the exclusion list
+            // Skip properties in the exclusion list or that have already been visited.
             if (!exclusions.contains(prop.propertyName) &&
                     (enteredTypes.getOrDefault(prop.rawTypeName, 0) <= 1)) {
                 List<JsonNode> propertyNodes = new ArrayList<>();

--- a/src/main/java/com/algorand/sdkutils/utils/StructDef.java
+++ b/src/main/java/com/algorand/sdkutils/utils/StructDef.java
@@ -47,10 +47,14 @@ public class StructDef implements Comparable<StructDef> {
 
     @Override
     public String toString() {
-        return "name: '" + name + "', " +
+        return "{name: '" + name + "', " +
+                "aliasOf: '" + aliasOf + "', " +
                 "doc: '" + doc + "', " +
-                "required: ['" + String.join("', '", requiredProperties) + "'], " +
-                "mutuallyExclusive: ['" + String.join("', '", mutuallyExclusiveProperties) + "']";
+                "properties: " + properties.size() + ", " +
+                "requiredProperties: ['" +
+                String.join("', '", requiredProperties) + "'], " +
+                "mutuallyExclusiveProperties: ['" +
+                String.join("', '", mutuallyExclusiveProperties) + "']}";
     }
 
     @Override


### PR DESCRIPTION
Previously the response generator crashed with stack overflow because of recursion through inner transactions in the oas file. This change limits the number of times we enter the same type, and thus fixes infinite recursion.