### PR TITLE
Fix Go source generation with type = string and format = byte

### DIFF
--- a/go_templates/common_macros.vm
+++ b/go_templates/common_macros.vm
@@ -13,6 +13,8 @@ string##
 types.Block
 #elseif( $setter && ($param.algorandFormat == "base64" || $param.type == "binary" || $param.format == "binary" ) )
 []byte##
+#elseif( $param.type == "string" && $param.format == "byte" )
+[]byte##
 #elseif( $param.type == "binary" )
 string##
 #elseif ( $param.type == "integer" )


### PR DESCRIPTION
Patches an issue with Go `[]byte` generation observed in https://github.com/algorand/go-algorand-sdk/pull/316#discussion_r872584788 by copying an analogous condition from `go_templates/model.vm` into `go_templates/common_macros.vm`.