### PR TITLE
Generate code for enums in definition blocks

### DIFF
--- a/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -524,12 +524,18 @@ public class OpenApiParser {
                 null ? root.get("components").get("schemas") : root.get("definitions");
                 for (Map.Entry<String, JsonNode> cls : getSortedSchema(schemas).entrySet()) {
                     String desc = null;
+                    if (cls.getValue().get("description") != null) {
+                        desc = cls.getValue().get("description").asText();
+                    }
+
+                    TypeDef clsType = getType(cls.getValue(), true, cls.getKey(), false, false);
+                    if (clsType.isOfType("enum")) {
+                        publisher.publish(Events.NEW_PROPERTY, clsType);
+                    }
+
                     if (!hasProperties(cls.getValue())) {
                         // If it has no properties, no class is needed for this type.
                         continue;
-                    }
-                    if (cls.getValue().get("description") != null) {
-                        desc = cls.getValue().get("description").asText();
                     }
                     String className = Tools.getCamelCase(cls.getKey(), true);
                     if (!filterList.isEmpty() && filterList.contains(className)) {

--- a/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -530,7 +530,7 @@ public class OpenApiParser {
 
                     TypeDef clsType = getType(cls.getValue(), true, cls.getKey(), false, false);
                     if (clsType.isOfType("enum")) {
-                        publisher.publish(Events.NEW_PROPERTY, clsType);
+                        publisher.publish(Events.ENUM_DEFINITION, clsType);
                     }
 
                     if (!hasProperties(cls.getValue())) {

--- a/src/main/java/com/algorand/sdkutils/listeners/JavaGenerator.java
+++ b/src/main/java/com/algorand/sdkutils/listeners/JavaGenerator.java
@@ -118,6 +118,9 @@ public class JavaGenerator implements Subscriber {
         case BODY_CONTENT:
             javaQueryWriter.addQueryProperty(type, false, false, true);
             break;
+        case ENUM_DEFINITION:
+            this.storeEnumDefinition(type);
+            break;
         default:
             throw new RuntimeException("Unimplemented event for TypeDef! " + event);
         }

--- a/src/main/java/com/algorand/sdkutils/listeners/Publisher.java
+++ b/src/main/java/com/algorand/sdkutils/listeners/Publisher.java
@@ -14,6 +14,9 @@ public class Publisher {
     public enum Events {
         ALL,
 
+        // Store an enum definition--some languages will just treat enums as strings.
+        ENUM_DEFINITION,
+
         // Define a model object.
         NEW_MODEL,
         NEW_PROPERTY,

--- a/src/main/java/com/algorand/sdkutils/listeners/TemplateGenerator.java
+++ b/src/main/java/com/algorand/sdkutils/listeners/TemplateGenerator.java
@@ -291,9 +291,6 @@ public class TemplateGenerator implements Subscriber {
     public void onEvent(Publisher.Events event, TypeDef type) {
         switch(event) {
             case NEW_PROPERTY:
-                if (type.isOfType("enum")) {
-                    break;
-                }
                 activeList.add(type);
                 //javaModelWriter.newProperty(type);
                 break;
@@ -305,6 +302,9 @@ public class TemplateGenerator implements Subscriber {
                 break;
             case BODY_CONTENT:
                 activeQuery.bodyParameters.add(type);
+                break;
+            case ENUM_DEFINITION:
+                // do nothing for enum definitions
                 break;
             default:
                 logger.info("unhandled event (Events, TypeDef): {}", event);

--- a/src/main/java/com/algorand/sdkutils/listeners/TemplateGenerator.java
+++ b/src/main/java/com/algorand/sdkutils/listeners/TemplateGenerator.java
@@ -291,6 +291,9 @@ public class TemplateGenerator implements Subscriber {
     public void onEvent(Publisher.Events event, TypeDef type) {
         switch(event) {
             case NEW_PROPERTY:
+                if (type.isOfType("enum")) {
+                    break;
+                }
                 activeList.add(type);
                 //javaModelWriter.newProperty(type);
                 break;


### PR DESCRIPTION
This updates the generator to address #19 --it generates enums in the `Enums.java` file which include any enums listed in the definitions section. The template generator was also updated to ignore these since the go sdk generated using the template generator does not have a concept of enums really.
