### PR TITLE
Build: Sdk code generation

### DIFF
--- a/.github/actions/sdk-codegen/Dockerfile
+++ b/.github/actions/sdk-codegen/Dockerfile
@@ -1,0 +1,57 @@
+FROM golang:1.17.9-bullseye
+
+ARG GITHUB_CLI_URL="https://github.com/cli/cli/releases/download/v1.8.1/gh_1.8.1_linux_amd64.tar.gz"
+
+# Manually install npm
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y maven openjdk-17-jdk nodejs
+
+ENV TMP_DIR=/tmp
+ENV GH_DIR=$TMP_DIR/gh
+WORKDIR $TMP_DIR
+# Install GitHub cli
+RUN mkdir $GH_DIR \
+  && curl -L ${GITHUB_CLI_URL} | tar -xz --strip-components=1 -C $GH_DIR \
+  && ln -s $GH_DIR/bin/gh /bin/gh
+
+# ------------------------------------
+# Required environment variables
+# ------------------------------------
+# GitHub username
+ENV GITHUB_USER="codegen-user"
+# GitHub email
+ENV GITHUB_EMAIL="codegen@algorand.com"
+# SDK repository in OWNER/REPO format
+ENV GITHUB_URL_BASE="https://github.com/"
+ENV GO_ALGORAND_REPO="algorand/go-algorand"
+ENV INDEXER_REPO="algorand/indexer"
+ENV JS_SDK_REPO="Eric-Warehime/js-algorand-sdk"
+ENV GO_SDK_REPO="Eric-Warehime/go-algorand-sdk"
+ENV JAVA_SDK_REPO="Eric-Warehime/java-algorand-sdk"
+
+# ------------------------------------
+# Utility environment variables
+# ------------------------------------
+ENV GO_ALGORAND_DIR="/clones/go-algorand"
+ENV INDEXER_DIR="/clones/indexer"
+ENV GENERATOR_DIR="/clones/generator"
+
+# Retrieve spec files
+RUN git clone $GITHUB_URL_BASE$GO_ALGORAND_REPO "$GO_ALGORAND_DIR"
+RUN git clone $GITHUB_URL_BASE$INDEXER_REPO "$INDEXER_DIR"
+ENV ALGOD_SPEC="${GO_ALGORAND_DIR}/daemon/algod/api/algod.oas2.json"
+ENV INDEXER_SPEC="${INDEXER_DIR}/api/indexer.oas2.json"
+
+# Build generator 
+RUN git clone https://github.com/algorand/generator $GENERATOR_DIR
+WORKDIR $GENERATOR_DIR
+RUN mvn package
+ENV TEMPLATE="java -jar ${GENERATOR_DIR}/target/generator-*-jar-with-dependencies.jar template"
+ENV GENERATOR="java -jar ${GENERATOR_DIR}/target/generator-*-jar-with-dependencies.jar"
+
+# Run
+COPY publish.sh /publish.sh
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh && chmod +x /publish.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/sdk-codegen/Dockerfile
+++ b/.github/actions/sdk-codegen/Dockerfile
@@ -38,8 +38,8 @@ ENV INDEXER_DIR="/clones/indexer"
 ENV GENERATOR_DIR="/clones/generator"
 
 # Retrieve spec files
-RUN git clone $GITHUB_URL_BASE$GO_ALGORAND_REPO "$GO_ALGORAND_DIR"
-RUN git clone $GITHUB_URL_BASE$INDEXER_REPO "$INDEXER_DIR"
+RUN git clone --depth 1 $GITHUB_URL_BASE$GO_ALGORAND_REPO "$GO_ALGORAND_DIR"
+RUN git clone --depth 1 $GITHUB_URL_BASE$INDEXER_REPO "$INDEXER_DIR"
 ENV ALGOD_SPEC="${GO_ALGORAND_DIR}/daemon/algod/api/algod.oas2.json"
 ENV INDEXER_SPEC="${INDEXER_DIR}/api/indexer.oas2.json"
 

--- a/.github/actions/sdk-codegen/Dockerfile
+++ b/.github/actions/sdk-codegen/Dockerfile
@@ -44,7 +44,7 @@ ENV ALGOD_SPEC="${GO_ALGORAND_DIR}/daemon/algod/api/algod.oas2.json"
 ENV INDEXER_SPEC="${INDEXER_DIR}/api/indexer.oas2.json"
 
 # Build generator 
-RUN git clone https://github.com/algorand/generator $GENERATOR_DIR
+RUN git clone --depth 1 https://github.com/algorand/generator $GENERATOR_DIR
 WORKDIR $GENERATOR_DIR
 RUN mvn package
 ENV TEMPLATE="java -jar ${GENERATOR_DIR}/target/generator-*-jar-with-dependencies.jar template"

--- a/.github/actions/sdk-codegen/Dockerfile
+++ b/.github/actions/sdk-codegen/Dockerfile
@@ -26,9 +26,9 @@ ENV GITHUB_EMAIL="codegen@algorand.com"
 ENV GITHUB_URL_BASE="https://github.com/"
 ENV GO_ALGORAND_REPO="algorand/go-algorand"
 ENV INDEXER_REPO="algorand/indexer"
-ENV JS_SDK_REPO="Eric-Warehime/js-algorand-sdk"
-ENV GO_SDK_REPO="Eric-Warehime/go-algorand-sdk"
-ENV JAVA_SDK_REPO="Eric-Warehime/java-algorand-sdk"
+ENV JS_SDK_REPO="algorand/js-algorand-sdk"
+ENV GO_SDK_REPO="algorand/go-algorand-sdk"
+ENV JAVA_SDK_REPO="algorand/java-algorand-sdk"
 
 # ------------------------------------
 # Utility environment variables

--- a/.github/actions/sdk-codegen/entrypoint.sh
+++ b/.github/actions/sdk-codegen/entrypoint.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -e
+
+function help() {
+  echo "Entry point of our sdk code gen container."
+  echo "-k|--sdk             - Which sdk to generate (GO,JS,JAVA,ALL)"
+  exit
+}
+
+PARAMS=""
+
+while (( "$#" )); do
+  case "$1" in
+    -k|--sdk)
+      shift
+      SDK=$1
+      ;;
+    -h)
+      help
+      ;;
+    -*|--*=) # unsupported flags
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *) # preserve positional arguments
+      PARAMS="$PARAMS $1"
+      ;;
+  esac
+  shift
+done
+# set positional arguments in their proper place
+eval set -- "$PARAMS"
+
+function generate_js {
+  JS_SDK_DIR=/clones/js-algorand-sdk
+  TEMPLATE_DIR=$GENERATOR_DIR/typescript_templates
+  export GH_REPO=$JS_SDK_REPO
+  git clone https://github.com/Eric-Warehime/js-algorand-sdk $JS_SDK_DIR
+  # Generate algod.
+  $TEMPLATE \
+    -s "$ALGOD_SPEC" \
+    -t "$TEMPLATE_DIR" \
+    -m "$JS_SDK_DIR/src/client/v2/algod/models" \
+    -p "$TEMPLATE_DIR/common_config.properties,$TEMPLATE_DIR/parameter_order_overrides.properties"
+
+  pushd $JS_SDK_DIR
+  npm install
+  make format
+  /publish.sh
+}
+
+function generate_go {
+  GO_SDK_DIR=/clones/go-algorand-sdk
+  TEMPLATE_DIR=$GENERATOR_DIR/go_templates
+  export GH_REPO=$GO_SDK_REPO
+  git clone https://github.com/Eric-Warehime/go-algorand-sdk $GO_SDK_DIR
+  # Generate algod.
+  $TEMPLATE \
+    -s $ALGOD_SPEC \
+    -t $TEMPLATE_DIR \
+    -m $GO_SDK_DIR/client/v2/common/models \
+    -q $GO_SDK_DIR/client/v2/algod \
+    -c $GO_SDK_DIR/client/v2/algod \
+    -p $TEMPLATE_DIR/common_config.properties,$TEMPLATE_DIR/algod_config.properties
+
+  # Generate indexer.
+  $TEMPLATE \
+    -s $INDEXER_SPEC \
+    -t $TEMPLATE_DIR \
+    -m $GO_SDK_DIR/client/v2/common/models \
+    -q $GO_SDK_DIR/client/v2/indexer \
+    -c $GO_SDK_DIR/client/v2/indexer \
+    -p $TEMPLATE_DIR/common_config.properties,$TEMPLATE_DIR/indexer_config.properties
+
+  pushd $GO_SDK_DIR
+  go fmt ./...
+  /publish.sh
+}
+
+function generate_java {
+  JAVA_SDK_DIR=/clones/java-algorand-sdk
+  export GH_REPO=$JAVA_SDK_REPO
+  git clone https://github.com/Eric-Warehime/java-algorand-sdk $JAVA_SDK_DIR
+
+ $GENERATOR \
+    java \
+    -c  "$JAVA_SDK_DIR/src/main/java/com/algorand/algosdk/v2/client/common" \
+    -cp "com.algorand.algosdk.v2.client.common" \
+    -m  "$JAVA_SDK_DIR/src/main/java/com/algorand/algosdk/v2/client/model" \
+    -mp "com.algorand.algosdk.v2.client.model" \
+    -n  "AlgodClient" \
+    -p  "$JAVA_SDK_DIR/src/main/java/com/algorand/algosdk/v2/client/algod" \
+    -pp "com.algorand.algosdk.v2.client.algod" \
+    -t  "X-Algo-API-Token" \
+    -tr \
+    -s  "$ALGOD_SPEC"
+
+  # There is one enum only defined by indexer. Run this second to avoid
+  # overwriting the second one.
+  $GENERATOR \
+    java \
+    -c  "$JAVA_SDK_DIR/src/main/java/com/algorand/algosdk/v2/client/common" \
+    -cp "com.algorand.algosdk.v2.client.common" \
+    -m  "$JAVA_SDK_DIR/src/main/java/com/algorand/algosdk/v2/client/model" \
+    -mp "com.algorand.algosdk.v2.client.model" \
+    -n  "IndexerClient" \
+    -p  "$JAVA_SDK_DIR/src/main/java/com/algorand/algosdk/v2/client/indexer" \
+    -pp "com.algorand.algosdk.v2.client.indexer" \
+    -t  "X-Indexer-API-Token" \
+    -s  "$INDEXER_SPEC" 
+
+  pushd $JAVA_SDK_DIR
+  /publish.sh
+
+}
+
+function generate() {
+  if [ -z "$SDK" ]
+  then
+    echo "Must define SDK to be generated!"
+    help
+    exit 1
+  fi
+  case "$1" in
+    GO)
+      generate_go
+      ;;
+    JS)
+      generate_js
+      ;;
+    JAVA)
+      generate_java
+      ;;
+    ALL)
+      generate_go
+      generate_js
+      generate_java
+      ;;
+    *):
+      echo "SDK generation for  $1 is not defined. Must be one of JS|GO|JAVA|ALL." >&2
+      exit 1
+  esac
+}
+
+generate $SDK
+

--- a/.github/actions/sdk-codegen/entrypoint.sh
+++ b/.github/actions/sdk-codegen/entrypoint.sh
@@ -30,7 +30,7 @@ function generate_js {
   JS_SDK_DIR=/clones/js-algorand-sdk
   TEMPLATE_DIR=$GENERATOR_DIR/typescript_templates
   export GH_REPO=$JS_SDK_REPO
-  git clone https://github.com/algorand/js-algorand-sdk $JS_SDK_DIR
+  git clone --depth 1 https://github.com/algorand/js-algorand-sdk $JS_SDK_DIR
   # Generate algod.
   $TEMPLATE \
     -s "$ALGOD_SPEC" \

--- a/.github/actions/sdk-codegen/entrypoint.sh
+++ b/.github/actions/sdk-codegen/entrypoint.sh
@@ -35,7 +35,7 @@ function generate_js {
   JS_SDK_DIR=/clones/js-algorand-sdk
   TEMPLATE_DIR=$GENERATOR_DIR/typescript_templates
   export GH_REPO=$JS_SDK_REPO
-  git clone https://github.com/Eric-Warehime/js-algorand-sdk $JS_SDK_DIR
+  git clone https://github.com/algorand/js-algorand-sdk $JS_SDK_DIR
   # Generate algod.
   $TEMPLATE \
     -s "$ALGOD_SPEC" \
@@ -53,7 +53,7 @@ function generate_go {
   GO_SDK_DIR=/clones/go-algorand-sdk
   TEMPLATE_DIR=$GENERATOR_DIR/go_templates
   export GH_REPO=$GO_SDK_REPO
-  git clone https://github.com/Eric-Warehime/go-algorand-sdk $GO_SDK_DIR
+  git clone https://github.com/algorand/go-algorand-sdk $GO_SDK_DIR
   # Generate algod.
   $TEMPLATE \
     -s $ALGOD_SPEC \
@@ -80,7 +80,7 @@ function generate_go {
 function generate_java {
   JAVA_SDK_DIR=/clones/java-algorand-sdk
   export GH_REPO=$JAVA_SDK_REPO
-  git clone https://github.com/Eric-Warehime/java-algorand-sdk $JAVA_SDK_DIR
+  git clone https://github.com/algorand/java-algorand-sdk $JAVA_SDK_DIR
 
  $GENERATOR \
     java \

--- a/.github/actions/sdk-codegen/entrypoint.sh
+++ b/.github/actions/sdk-codegen/entrypoint.sh
@@ -106,7 +106,6 @@ function generate_java {
 
   pushd $JAVA_SDK_DIR
   /publish.sh
-
 }
 
 function generate() {

--- a/.github/actions/sdk-codegen/entrypoint.sh
+++ b/.github/actions/sdk-codegen/entrypoint.sh
@@ -18,18 +18,13 @@ while (( "$#" )); do
     -h)
       help
       ;;
-    -*|--*=) # unsupported flags
+    *) # unsupported flags
       echo "Error: Unsupported flag $1" >&2
       exit 1
-      ;;
-    *) # preserve positional arguments
-      PARAMS="$PARAMS $1"
       ;;
   esac
   shift
 done
-# set positional arguments in their proper place
-eval set -- "$PARAMS"
 
 function generate_js {
   JS_SDK_DIR=/clones/js-algorand-sdk

--- a/.github/actions/sdk-codegen/publish.sh
+++ b/.github/actions/sdk-codegen/publish.sh
@@ -83,8 +83,8 @@ git -c core.hooksPath=/dev/null push --set-upstream origin $PR_BRANCH # disable 
 # ==============================
 
 # Design PR content
-ALGOD_REPO_URL="https://github.com/Eric-Warehime/go-algorand"
-INDEXER_REPO_URL="https://github.com/Eric-Warehime/indexer"
+ALGOD_REPO_URL="https://github.com/algorand/go-algorand"
+INDEXER_REPO_URL="https://github.com/algorand/indexer"
 
 PR_BODY="This PR was automatically created using [Algorand's code generator](https://github.com/algorand/generator), in response to the following commits:
 
@@ -109,4 +109,3 @@ gh pr create \
   $BASE_ARG_PAIR \
   --title "Regenerate code with the latest specification file ($PR_ID)" \
   --body "$PR_BODY"
-# --label "generated"

--- a/.github/actions/sdk-codegen/publish.sh
+++ b/.github/actions/sdk-codegen/publish.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -e
+
+# Don't continue if there are no files in the /repo directory
+if [ -z "$(ls -A ./)" ]; then
+  echo "Error: directory is empty"
+  exit 1
+fi
+
+# Don't continue if there were no changes
+if git diff-index --quiet HEAD --; then
+  echo "No changes after code generation, stopping"
+  exit 0
+fi
+
+# ============================================================
+# > SET UP GIT
+# ------------------------------------------------------------
+#
+# GitHub credentials require only a `GITHUB_TOKEN` environment
+# variable, but `git` credentials require explicit setup.
+#
+# ============================================================
+
+git config credential.helper '!f() { sleep 1; echo "username=${GITHUB_USER}"; echo "password=${GITHUB_TOKEN}"; }; f'
+git config --global user.name "Algorand Generation Bot"
+git config --global user.email "$GITHUB_EMAIL"
+
+# ========================================================
+# > EXPORT DATA FROM SPEC FILES
+# ========================================================
+
+pushd "$GO_ALGORAND_DIR" > /dev/null
+export ALGOD_SPEC_HASH=`git log -n 1 --pretty=format:%h -- daemon/algod/api/algod.oas2.json`
+export ALGOD_SPEC_COMMIT_MSG=`git log -n 1 --pretty=format:%s -- daemon/algod/api/algod.oas2.json`
+popd > /dev/null
+pushd "$INDEXER_DIR" > /dev/null
+export INDEXER_SPEC_HASH=`git log -n 1 --pretty=format:%h -- api/indexer.oas2.json`
+export INDEXER_SPEC_COMMIT_MSG=`git log -n 1 --pretty=format:%s -- api/indexer.oas2.json`
+popd > /dev/null
+
+# ==============================
+# > CREATE BRANCH
+# ==============================
+
+# Generate an identifier for this PR (first four chars of algod/indexer hashes, concatenated)
+PR_ID="${ALGOD_SPEC_HASH:0:4}${INDEXER_SPEC_HASH:0:4}"
+PR_BRANCH="generate/$PR_ID"
+
+# Don't continue if a remote branch has already been created
+REMOTE_PR_BRANCH_EXISTS=`git ls-remote origin $PR_BRANCH | wc -l`
+if [ $REMOTE_PR_BRANCH_EXISTS -eq 1 ]; then
+  echo "Generated branch already exists, stopping"
+  exit 0
+fi
+
+# Delete the branch if it exists locally
+PR_BRANCH_EXISTS=`git branch -v | grep $PR_BRANCH | wc -l`
+if [ $PR_BRANCH_EXISTS -eq 1 ]; then
+  git -c core.hooksPath=/dev/null checkout $BRANCH # disable git hooks https://stackoverflow.com/a/61485071
+  git branch -D $PR_BRANCH > /dev/null
+fi
+
+# Create a new branch
+git -c core.hooksPath=/dev/null checkout -b $PR_BRANCH # disable git hooks https://stackoverflow.com/a/61485071
+
+# Exit without error if there are no changes to commit
+CHANGED=`git diff --name-only HEAD --`
+if [ -z "$CHANGED" ]; then
+  echo "No new changes, exiting"
+  exit 0
+fi
+
+# Create commit and store hash
+git add .
+git commit --no-verify -m "Regenerate code from specification file"
+
+# Push
+git -c core.hooksPath=/dev/null push --set-upstream origin $PR_BRANCH # disable git hooks https://stackoverflow.com/a/61485071
+
+# ==============================
+# > CREATE A PR
+# ==============================
+
+# Design PR content
+ALGOD_REPO_URL="https://github.com/Eric-Warehime/go-algorand"
+INDEXER_REPO_URL="https://github.com/Eric-Warehime/indexer"
+
+PR_BODY="This PR was automatically created using [Algorand's code generator](https://github.com/algorand/generator), in response to the following commits:
+
+### Algod
+
+ - [$ALGOD_SPEC_HASH]($ALGOD_REPO_URL/commit/$ALGOD_SPEC_HASH) – $ALGOD_SPEC_COMMIT_MSG
+
+### Indexer
+
+ - [$INDEXER_SPEC_HASH]($INDEXER_REPO_URL/commit/$INDEXER_SPEC_HASH) - $INDEXER_SPEC_COMMIT_MSG
+
+
+> **Disclaimer:** I'm just a bot. Feel free to make changes to this pull request as needed."
+
+# Only set the branch base if a BRANCH environment variable has been set
+if [[ ! -z "$BRANCH" ]]; then
+  BASE_ARG_PAIR="--base $BRANCH"
+fi
+
+gh pr create \
+  --repo $GH_REPO \
+  $BASE_ARG_PAIR \
+  --title "Regenerate code with the latest specification file ($PR_ID)" \
+  --body "$PR_BODY"
+# --label "generated"

--- a/.github/actions/sdk-codegen/sdk-gen.yml
+++ b/.github/actions/sdk-codegen/sdk-gen.yml
@@ -1,0 +1,9 @@
+name: "sdk-gen"
+description: "Uses models to run SDK code generation and cut a PR in case of changes."
+inputs:
+  sdk:
+    description: "Which SDK to generate."
+    required: true
+runs:
+  using: "docker"
+  image: "Dockerfile"


### PR DESCRIPTION
## Summary
Adds a github action which can be used by SDKs to automatically generate code and open pull requests.

Currently this automation resides in https://github.com/algorand/generator/tree/master/automation as well as in some of the SDK repos themselves, but it has some issues from lack of maintenance and isn't being used.

The `publish.sh` file I've taken nearly exactly from what the existing script as it just works.  
The `entrypoint.sh` is a mix of the `scripts/generate_{language}.sh` and the existing `Dockerfile` in the automation.

I've moved all of this into a Github Action so that we can have a central location that defines our code generation logic, and then utilize that across each of our SDK repos via a nightly workflow.

## Testing
I've run the workflow on my personal forks (so there may be some permissions issues to sort out once we merge this), and have successful runs for generating a PR:  
https://github.com/Eric-Warehime/go-algorand-sdk/actions/runs/2386518280  
https://github.com/Eric-Warehime/go-algorand-sdk/pull/1 (comes from an outdated indexer API spec so ignore the content)  

And I have gotten a run which successfully no-ops because the branch with generated changes already exists:  
https://github.com/Eric-Warehime/go-algorand-sdk/actions/runs/2386615221
