### PR TITLE
.NET SDK Support

### DIFF
--- a/dotnet_templates/README.txt
+++ b/dotnet_templates/README.txt
@@ -1,0 +1,3 @@
+EXAMPLE FOR GENERATING TRANSACTION MODEL:
+
+java -jar generator-1.0.0-jar-with-dependencies.jar template -s ..\dotnet_templates\Transactions.json -t ..\dotnet_templates -m ..\output_txns -p "..\dotnet_templates\transactions_model_config.properties"

--- a/dotnet_templates/README.txt
+++ b/dotnet_templates/README.txt
@@ -1,3 +1,13 @@
 EXAMPLE FOR GENERATING TRANSACTION MODEL:
 
 java -jar generator-1.0.0-jar-with-dependencies.jar template -s ..\dotnet_templates\Transactions.json -t ..\dotnet_templates -m ..\output_txns -p "..\dotnet_templates\transactions_model_config.properties"
+
+EXAMPLE FOR GENERATING ALGOD MODEL:
+java -jar generator-1.0.0-jar-with-dependencies.jar template -s algod.oas2.json -t ..\dotnet_templates -m ..\output  -p "..\dotnet_templates\algod_model_config.properties"
+
+FOR ALGOD COMMON CLIENT: 
+java -jar generator-1.0.0-jar-with-dependencies.jar template -s algod.oas2.json -t ..\dotnet_templates -c ..\output_client  -p "..\dotnet_templates\algod_common_config.properties"
+
+FOR ALGOD DEFAULT CLIENT: 
+java -jar generator-1.0.0-jar-with-dependencies.jar template -s algod.oas2.json -t ..\dotnet_templates -c ..\output_client  -p "..\dotnet_templates\algod_default_config.properties"
+

--- a/dotnet_templates/Transactions.json
+++ b/dotnet_templates/Transactions.json
@@ -1,983 +1,1236 @@
 {
-    "openapi": "3.0.1",
-    "info": {
-      "title": "AlgodProxy",
-      "version": "v1"
-    },
-    "paths": {
-      "/Algod": {
-        "get": {
-          "tags": [
-            "Algod"
-          ],
-          "responses": {
-            "200": {
-              "description": "Success",
-              "content": {
-                "text/plain": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.SignedTransaction"
-                  }
-                },
-                "application/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.SignedTransaction"
-                  }
-                },
-                "text/json": {
-                  "schema": {
-                    "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.SignedTransaction"
-                  }
-                }
-              }
-            }
+  "openapi": "3.0.1",
+  "info": {
+    "title": "AlgodProxy",
+    "version": "v1"
+  },
+  "paths": {
+    
+  },
+  "components": {
+    "schemas": {
+      "Algorand.Address": {
+        "type": "object",
+        "properties": {
+          "bytes": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "x-algorand-longname": "Bytes"
           }
-        }
-      }
-    },
-    "components": {
-      "schemas": {
-        "Algorand.Address": {
-          "type": "object",
-          "properties": {
-            "bytes": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
         },
-        "Algorand.Algod.Model.AssetParams": {
-          "type": "object",
-          "properties": {
-            "c": {
+        "additionalProperties": false
+      },
+      "Algorand.Algod.Model.AssetParams": {
+        "type": "object",
+        "properties": {
+          "c": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "Clawback"
+          },
+          "clawback": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "clawback"
+          },
+          "creator": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "creator"
+          },
+          "dc": {
+            "maximum": 19,
+            "minimum": 0,
+            "type": "integer",
+            "format": "int64",
+            "x-algorand-longname": "Decimals"
+          },
+          "decimals": {
+            "type": "integer",
+            "format": "int64",
+            "writeOnly": true,
+            "x-algorand-longname": "decimals"
+          },
+          "df": {
+            "type": "boolean",
+            "default": false,
+            "nullable": true,
+            "x-algorand-longname": "DefaultFrozen"
+          },
+          "default-frozen": {
+            "type": "boolean",
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "defaultFrozen"
+          },
+          "f": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "Freeze"
+          },
+          "freeze": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "freeze"
+          },
+          "m": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "Manager"
+          },
+          "manager": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "manager"
+          },
+          "am": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "x-algorand-longname": "MetadataHash"
+          },
+          "metadata-hash": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "metadataHash"
+          },
+          "an": {
+            "type": "string",
+            "nullable": true,
+            "x-algorand-longname": "Name"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "name"
+          },
+          "name-b64": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "nameB64"
+          },
+          "r": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "Reserve"
+          },
+          "reserve": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "reserve"
+          },
+          "t": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "Total"
+          },
+          "total": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "total"
+          },
+          "un": {
+            "type": "string",
+            "nullable": true,
+            "x-algorand-longname": "UnitName"
+          },
+          "unit-name": {
+            "type": "string",
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "unitName"
+          },
+          "unit-name-b64": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "unitNameB64"
+          },
+          "au": {
+            "type": "string",
+            "nullable": true,
+            "x-algorand-longname": "Url"
+          },
+          "url": {
+            "type": "string",
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "url"
+          },
+          "url-b64": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "urlB64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationCallTransaction": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Transaction"
+          }
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true,
+            "x-algorand-longname": "type"
+          },
+          "apat": {
+            "type": "array",
+            "items": {
               "$ref": "#/components/schemas/Algorand.Address"
             },
-            "clawback": {
-              "$ref": "#/components/schemas/Algorand.Address"
+            "nullable": true,
+            "x-algorand-longname": "Accounts"
+          },
+          "apaa": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "byte"
             },
-            "creator": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            },
-            "dc": {
-              "maximum": 19,
-              "minimum": 0,
+            "nullable": true,
+            "x-algorand-longname": "ApplicationArgs"
+          },
+          "apfa": {
+            "type": "array",
+            "items": {
               "type": "integer",
               "format": "int64"
             },
-            "decimals": {
-              "type": "integer",
-              "format": "int64",
-              "writeOnly": true
-            },
-            "df": {
-              "type": "boolean",
-              "default": false,
-              "nullable": true
-            },
-            "default-frozen": {
-              "type": "boolean",
-              "nullable": true,
-              "writeOnly": true
-            },
-            "f": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            },
-            "freeze": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            },
-            "m": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            },
-            "manager": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            },
-            "am": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true
-            },
-            "metadata-hash": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true,
-              "writeOnly": true
-            },
-            "an": {
-              "type": "string",
-              "nullable": true
-            },
-            "name": {
-              "type": "string",
-              "nullable": true,
-              "writeOnly": true
-            },
-            "name-b64": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true,
-              "writeOnly": true
-            },
-            "r": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            },
-            "reserve": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            },
-            "t": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "total": {
-              "type": "integer",
-              "format": "int64",
-              "nullable": true,
-              "writeOnly": true
-            },
-            "un": {
-              "type": "string",
-              "nullable": true
-            },
-            "unit-name": {
-              "type": "string",
-              "nullable": true,
-              "writeOnly": true
-            },
-            "unit-name-b64": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true,
-              "writeOnly": true
-            },
-            "au": {
-              "type": "string",
-              "nullable": true
-            },
-            "url": {
-              "type": "string",
-              "nullable": true,
-              "writeOnly": true
-            },
-            "url-b64": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true,
-              "writeOnly": true
-            }
+            "nullable": true,
+            "x-algorand-longname": "ForeignApps"
           },
-          "additionalProperties": false
-        },
-        "Algorand.Algod.Model.Transactions.ApplicationCallTransaction": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.Transaction"
-            }
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "nullable": true,
-              "readOnly": true
+          "apas": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
             },
-            "apat": {
-              "type": "array",
-              "items": {
+            "nullable": true,
+            "x-algorand-longname": "ForeignAssets"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationClearStateTransaction": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApplicationCallTransaction"
+          }
+        ],
+        "properties": {
+          "apid": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "x-algorand-longname": "ApplicationId"
+          },
+          "apan": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OnCompletion"
+              }
+            ],
+            "readOnly": true,
+            "x-algorand-longname": "OnCompletion"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationCloseOutTransaction": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApplicationCallTransaction"
+          }
+        ],
+        "properties": {
+          "apid": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "ApplicationId"
+          },
+          "apan": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OnCompletion"
+              }
+            ],
+            "readOnly": true,
+            "x-algorand-longname": "OnCompletion"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationCreateTransaction": {
+        "required": [
+          "apap",
+          "apgs",
+          "apls",
+          "apsu"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApplicationNoopTransaction"
+          }
+        ],
+        "properties": {
+          "apap": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.TEALProgram"
+              }
+            ],
+            "x-algorand-longname": "ApprovalProgram"
+          },
+          "apsu": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.TEALProgram"
+              }
+            ],
+            "x-algorand-longname": "ClearStateProgram"
+          },
+          "apgs": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StateSchema"
+              }
+            ],
+            "x-algorand-longname": "GlobalStateSchema"
+          },
+          "apls": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StateSchema"
+              }
+            ],
+            "x-algorand-longname": "LocalStateSchema"
+          },
+          "apep": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "ExtraProgramPages"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationDeleteTransaction": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApplicationCallTransaction"
+          }
+        ],
+        "properties": {
+          "apid": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "ApplicationId"
+          },
+          "apan": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OnCompletion"
+              }
+            ],
+            "readOnly": true,
+            "x-algorand-longname": "OnCompletion"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationNoopTransaction": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApplicationCallTransaction"
+          }
+        ],
+        "properties": {
+          "apid": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "ApplicationId"
+          },
+          "apan": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OnCompletion"
+              }
+            ],
+            "readOnly": true,
+            "x-algorand-longname": "OnCompletion"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationOptInTransaction": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApplicationCallTransaction"
+          }
+        ],
+        "properties": {
+          "apid": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "ApplicationId"
+          },
+          "apan": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OnCompletion"
+              }
+            ],
+            "readOnly": true,
+            "x-algorand-longname": "OnCompletion"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplicationUpdateTransaction": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ApplicationCallTransaction"
+          }
+        ],
+        "properties": {
+          "apid": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "ApplicationId"
+          },
+          "apan": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OnCompletion"
+              }
+            ],
+            "readOnly": true,
+            "x-algorand-longname": "OnCompletion"
+          },
+          "apap": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.TEALProgram"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "ApprovalProgram"
+          },
+          "apsu": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.TEALProgram"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "ClearStateProgram"
+          },
+          "apgs": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StateSchema"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "GlobalStateSchema"
+          },
+          "apls": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/StateSchema"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "LocalStateSchema"
+          },
+          "apep": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "ExtraProgramPages"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AssetAcceptTransaction": {
+        "required": [
+          "arcv"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AssetMovementsTransaction"
+          }
+        ],
+        "properties": {
+          "arcv": {
+            "allOf": [
+              {
                 "$ref": "#/components/schemas/Algorand.Address"
-              },
-              "nullable": true
-            },
-            "apaa": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "byte"
-              },
-              "nullable": true
-            },
-            "apfa": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "int64"
-              },
-              "nullable": true
-            },
-            "apas": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "format": "int64"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
+              }
+            ],
+            "x-algorand-longname": "AssetReceiver"
+          }
         },
-        "Algorand.Algod.Model.Transactions.ApplicationClearStateTransaction": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
-            }
-          ],
-          "properties": {
-            "apid": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0
-            },
-            "apan": {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.OnCompletion"
-            }
-          },
-          "additionalProperties": false
+        "additionalProperties": false
+      },
+      "AssetChangeTransaction": {
+        "required": [
+          "caid"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AssetConfigurationTransaction"
+          }
+        ],
+        "properties": {
+          "caid": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "x-algorand-longname": "AssetIndex"
+          }
         },
-        "Algorand.Algod.Model.Transactions.ApplicationCloseOutTransaction": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
-            }
-          ],
-          "properties": {
-            "apid": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "apan": {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.OnCompletion"
-            }
+        "additionalProperties": false
+      },
+      "AssetClawbackTransaction": {
+        "required": [
+          "aamt",
+          "arcv",
+          "asnd"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AssetMovementsTransaction"
+          }
+        ],
+        "properties": {
+          "aamt": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "x-algorand-longname": "AssetAmount"
           },
-          "additionalProperties": false
-        },
-        "Algorand.Algod.Model.Transactions.ApplicationCreateTransaction": {
-          "required": [
-            "apap",
-            "apgs",
-            "apls",
-            "apsu"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationNoopTransaction"
-            }
-          ],
-          "properties": {
-            "apap": {
-              "$ref": "#/components/schemas/Algorand.TEALProgram"
-            },
-            "apsu": {
-              "$ref": "#/components/schemas/Algorand.TEALProgram"
-            },
-            "apgs": {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.StateSchema"
-            },
-            "apls": {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.StateSchema"
-            },
-            "apep": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            }
+          "asnd": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "x-algorand-longname": "AssetSender"
           },
-          "additionalProperties": false
+          "arcv": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "x-algorand-longname": "AssetReceiver"
+          }
         },
-        "Algorand.Algod.Model.Transactions.ApplicationDeleteTransaction": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
-            }
-          ],
-          "properties": {
-            "apid": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "apan": {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.OnCompletion"
-            }
+        "additionalProperties": false
+      },
+      "AssetConfigurationTransaction": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Transaction"
+          }
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "readOnly": true,
+            "x-algorand-longname": "type"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AssetCreateTransaction": {
+        "required": [
+          "apar"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AssetConfigurationTransaction"
+          }
+        ],
+        "properties": {
+          "apar": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Algod.Model.AssetParams"
+              }
+            ],
+            "x-algorand-longname": "AssetParams"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AssetDestroyTransaction": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AssetChangeTransaction"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "AssetFreezeTransaction": {
+        "required": [
+          "fadd",
+          "faid",
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Transaction"
+          }
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "readOnly": true,
+            "x-algorand-longname": "type"
           },
-          "additionalProperties": false
-        },
-        "Algorand.Algod.Model.Transactions.ApplicationNoopTransaction": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
-            }
-          ],
-          "properties": {
-            "apid": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "apan": {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.OnCompletion"
-            }
+          "fadd": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "x-algorand-longname": "FreezeTarget"
           },
-          "additionalProperties": false
-        },
-        "Algorand.Algod.Model.Transactions.ApplicationOptInTransaction": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
-            }
-          ],
-          "properties": {
-            "apid": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "apan": {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.OnCompletion"
-            }
+          "faid": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "x-algorand-longname": "AssetFreezeID"
           },
-          "additionalProperties": false
+          "afrz": {
+            "type": "boolean",
+            "default": false,
+            "x-algorand-longname": "FreezeState"
+          }
         },
-        "Algorand.Algod.Model.Transactions.ApplicationUpdateTransaction": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
-            }
-          ],
-          "properties": {
-            "apid": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "apan": {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.OnCompletion"
-            },
-            "apap": {
-              "$ref": "#/components/schemas/Algorand.TEALProgram"
-            },
-            "apsu": {
-              "$ref": "#/components/schemas/Algorand.TEALProgram"
-            },
-            "apgs": {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.StateSchema"
-            },
-            "apls": {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.StateSchema"
-            },
-            "apep": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            }
+        "additionalProperties": false
+      },
+      "AssetMovementsTransaction": {
+        "required": [
+          "type",
+          "xaid"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Transaction"
+          }
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "readOnly": true,
+            "x-algorand-longname": "type"
           },
-          "additionalProperties": false
+          "xaid": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "x-algorand-longname": "XferAsset"
+          }
         },
-        "Algorand.Algod.Model.Transactions.AssetAcceptTransaction": {
-          "required": [
-            "arcv"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetMovementsTransaction"
-            }
-          ],
-          "properties": {
-            "arcv": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            }
+        "additionalProperties": false
+      },
+      "AssetTransferTransaction": {
+        "required": [
+          "aamt",
+          "arcv"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AssetMovementsTransaction"
+          }
+        ],
+        "properties": {
+          "aamt": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "x-algorand-longname": "AssetAmount"
           },
-          "additionalProperties": false
-        },
-        "Algorand.Algod.Model.Transactions.AssetChangeTransaction": {
-          "required": [
-            "caid"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetConfigurationTransaction"
-            }
-          ],
-          "properties": {
-            "caid": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0
-            }
+          "arcv": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "x-algorand-longname": "AssetReceiver"
           },
-          "additionalProperties": false
+          "aclose": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "AssetCloseTo"
+          }
         },
-        "Algorand.Algod.Model.Transactions.AssetClawbackTransaction": {
-          "required": [
-            "aamt",
-            "arcv",
-            "asnd"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetMovementsTransaction"
-            }
-          ],
-          "properties": {
-            "aamt": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0
-            },
-            "asnd": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            },
-            "arcv": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            }
+        "additionalProperties": false
+      },
+      "AssetUpdateTransaction": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AssetChangeTransaction"
+          }
+        ],
+        "properties": {
+          "apar": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Algod.Model.AssetParams"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "AssetParams"
+          }
+        },
+        "additionalProperties": false
+      },
+      "KeyRegisterOfflineTransaction": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/KeyRegistrationTransaction"
+          }
+        ],
+        "additionalProperties": false
+      },
+      "KeyRegisterOnlineTransaction": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/KeyRegistrationTransaction"
+          }
+        ],
+        "properties": {
+          "votekey": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.ParticipationPublicKey"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "VotePK"
           },
-          "additionalProperties": false
+          "selkey": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.VRFPublicKey"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "SelectionPK"
+          },
+          "votefst": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "VoteFirst"
+          },
+          "votelst": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "VoteLast"
+          },
+          "votekd": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "VoteKeyDilution"
+          },
+          "nonpart": {
+            "type": "boolean",
+            "default": false,
+            "nullable": true,
+            "x-algorand-longname": "NonParticipation"
+          }
         },
-        "Algorand.Algod.Model.Transactions.AssetConfigurationTransaction": {
-          "required": [
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.Transaction"
-            }
-          ],
-          "properties": {
-            "type": {
+        "additionalProperties": false
+      },
+      "KeyRegistrationTransaction": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Transaction"
+          }
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "readOnly": true,
+            "x-algorand-longname": "type"
+          }
+        },
+        "additionalProperties": false
+      },
+      "OnCompletion": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "PaymentTransaction": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Transaction"
+          }
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true,
+            "x-algorand-longname": "type"
+          },
+          "amt": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "Amount"
+          },
+          "amount": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "writeOnly": true,
+            "x-algorand-longname": "amount"
+          },
+          "rcv": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "Receiver"
+          },
+          "close": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "CloseRemainderTo"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SignedTransaction": {
+        "type": "object",
+        "properties": {
+          "txn": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Transaction"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "Tx"
+          },
+          "sig": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Signature"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "Sig"
+          },
+          "msig": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.MultisigSignature"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "MSig"
+          },
+          "lsig": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.LogicsigSignature"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "LSig"
+          },
+          "sgnr": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "AuthAddr"
+          }
+        },
+        "additionalProperties": false
+      },
+      "StateSchema": {
+        "type": "object",
+        "properties": {
+          "nui": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "NumUint"
+          },
+          "nbs": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "NumByteSlice"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Transaction": {
+        "type": "object",
+        "properties": {
+          "snd": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "Sender"
+          },
+          "fee": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "Fee"
+          },
+          "fv": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "FirstValid"
+          },
+          "lv": {
+            "type": "integer",
+            "format": "int64",
+            "default": 0,
+            "nullable": true,
+            "x-algorand-longname": "LastValid"
+          },
+          "note": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "x-algorand-longname": "Note"
+          },
+          "gen": {
+            "type": "string",
+            "default": "",
+            "nullable": true,
+            "x-algorand-longname": "GenesisID"
+          },
+          "gh": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Digest"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "GenesisHash"
+          },
+          "grp": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Digest"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "Group"
+          },
+          "lx": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "x-algorand-longname": "Lease"
+          },
+          "rekey": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Address"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "RekeyTo"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Algorand.Digest": {
+        "type": "object",
+        "properties": {
+          "bytes": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "x-algorand-longname": "Bytes"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Algorand.LogicsigSignature": {
+        "type": "object",
+        "properties": {
+          "l": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "x-algorand-longname": "Logic"
+          },
+          "arg": {
+            "type": "array",
+            "items": {
               "type": "string",
-              "readOnly": true
-            }
+              "format": "byte"
+            },
+            "nullable": true,
+            "x-algorand-longname": "Args"
           },
-          "additionalProperties": false
-        },
-        "Algorand.Algod.Model.Transactions.AssetCreateTransaction": {
-          "required": [
-            "apar"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetConfigurationTransaction"
-            }
-          ],
-          "properties": {
-            "apar": {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.AssetParams"
-            }
+          "sig": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Signature"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "Sig"
           },
-          "additionalProperties": false
+          "msig": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.MultisigSignature"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "Msig"
+          }
         },
-        "Algorand.Algod.Model.Transactions.AssetDestroyTransaction": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetChangeTransaction"
-            }
-          ],
-          "additionalProperties": false
-        },
-        "Algorand.Algod.Model.Transactions.AssetFreezeTransaction": {
-          "required": [
-            "fadd",
-            "faid",
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.Transaction"
-            }
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "readOnly": true
-            },
-            "fadd": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            },
-            "faid": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0
-            },
-            "afrz": {
-              "type": "boolean",
-              "default": false
-            }
+        "additionalProperties": false
+      },
+      "Algorand.MultisigSignature": {
+        "type": "object",
+        "properties": {
+          "v": {
+            "type": "integer",
+            "format": "int32",
+            "x-algorand-longname": "Version"
           },
-          "additionalProperties": false
-        },
-        "Algorand.Algod.Model.Transactions.AssetMovementsTransaction": {
-          "required": [
-            "type",
-            "xaid"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.Transaction"
-            }
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "readOnly": true
-            },
-            "xaid": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0
-            }
+          "thr": {
+            "type": "integer",
+            "format": "int32",
+            "x-algorand-longname": "Threshold"
           },
-          "additionalProperties": false
+          "subsig": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Algorand.MultisigSubsig"
+            },
+            "nullable": true,
+            "x-algorand-longname": "Subsigs"
+          }
         },
-        "Algorand.Algod.Model.Transactions.AssetTransferTransaction": {
-          "required": [
-            "aamt",
-            "arcv"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetMovementsTransaction"
-            }
-          ],
-          "properties": {
-            "aamt": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0
-            },
-            "arcv": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            },
-            "aclose": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            }
+        "additionalProperties": false
+      },
+      "Algorand.MultisigSubsig": {
+        "type": "object",
+        "properties": {
+          "pk": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Org.BouncyCastle.Crypto.Parameters.Ed25519PublicKeyParameters"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "key"
           },
-          "additionalProperties": false
+          "s": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Algorand.Signature"
+              }
+            ],
+            "nullable": true,
+            "x-algorand-longname": "sig"
+          }
         },
-        "Algorand.Algod.Model.Transactions.AssetUpdateTransaction": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetChangeTransaction"
-            }
-          ],
-          "properties": {
-            "apar": {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.AssetParams"
-            }
-          },
-          "additionalProperties": false
+        "additionalProperties": false
+      },
+      "Algorand.ParticipationPublicKey": {
+        "type": "object",
+        "properties": {
+          "bytes": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "x-algorand-longname": "Bytes"
+          }
         },
-        "Algorand.Algod.Model.Transactions.KeyRegisterOfflineTransaction": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.KeyRegistrationTransaction"
-            }
-          ],
-          "additionalProperties": false
+        "additionalProperties": false
+      },
+      "Algorand.Signature": {
+        "type": "object",
+        "properties": {
+          "bytes": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "readOnly": true,
+            "x-algorand-longname": "Bytes"
+          }
         },
-        "Algorand.Algod.Model.Transactions.KeyRegisterOnlineTransaction": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.KeyRegistrationTransaction"
-            }
-          ],
-          "properties": {
-            "votekey": {
-              "$ref": "#/components/schemas/Algorand.ParticipationPublicKey"
-            },
-            "selkey": {
-              "$ref": "#/components/schemas/Algorand.VRFPublicKey"
-            },
-            "votefst": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "votelst": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "votekd": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "nonpart": {
-              "type": "boolean",
-              "default": false,
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
+        "additionalProperties": false
+      },
+      "Algorand.TEALProgram": {
+        "type": "object",
+        "properties": {
+          "bytes": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "readOnly": true,
+            "x-algorand-longname": "Bytes"
+          }
         },
-        "Algorand.Algod.Model.Transactions.KeyRegistrationTransaction": {
-          "required": [
-            "type"
-          ],
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.Transaction"
-            }
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "readOnly": true
-            }
-          },
-          "additionalProperties": false
+        "additionalProperties": false
+      },
+      "Algorand.VRFPublicKey": {
+        "type": "object",
+        "properties": {
+          "bytes": {
+            "type": "string",
+            "format": "byte",
+            "nullable": true,
+            "x-algorand-longname": "Bytes"
+          }
         },
-        "Algorand.Algod.Model.Transactions.OnCompletion": {
-          "enum": [
-            0,
-            1,
-            2,
-            3,
-            4,
-            5
-          ],
-          "type": "integer",
-          "format": "int32"
-        },
-        "Algorand.Algod.Model.Transactions.PaymentTransaction": {
-          "type": "object",
-          "allOf": [
-            {
-              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.Transaction"
-            }
-          ],
-          "properties": {
-            "type": {
-              "type": "string",
-              "nullable": true,
-              "readOnly": true
-            },
-            "amt": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "amount": {
-              "type": "integer",
-              "format": "int64",
-              "nullable": true,
-              "writeOnly": true
-            },
-            "rcv": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            },
-            "close": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            }
-          },
-          "additionalProperties": false
-        },
-        "Algorand.Algod.Model.Transactions.SignedTransaction": {
-          "type": "object",
-          "properties": {
-            "txn": {
-              "oneOf": [
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationClearStateTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCloseOutTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCreateTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationDeleteTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationNoopTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationOptInTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationUpdateTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetAcceptTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetChangeTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetClawbackTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetConfigurationTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetCreateTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetDestroyTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetFreezeTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetMovementsTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetTransferTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetUpdateTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.KeyRegisterOfflineTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.KeyRegisterOnlineTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.KeyRegistrationTransaction"
-                },
-                {
-                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.PaymentTransaction"
-                }
-              ],
-              "nullable": true
-            },
-            "sig": {
-              "$ref": "#/components/schemas/Algorand.Signature"
-            },
-            "msig": {
-              "$ref": "#/components/schemas/Algorand.MultisigSignature"
-            },
-            "lsig": {
-              "$ref": "#/components/schemas/Algorand.LogicsigSignature"
-            },
-            "sgnr": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            }
-          },
-          "additionalProperties": false
-        },
-        "Algorand.Algod.Model.Transactions.StateSchema": {
-          "type": "object",
-          "properties": {
-            "nui": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "nbs": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Algorand.Algod.Model.Transactions.Transaction": {
-          "type": "object",
-          "properties": {
-            "snd": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            },
-            "fee": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "fv": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "lv": {
-              "type": "integer",
-              "format": "int64",
-              "default": 0,
-              "nullable": true
-            },
-            "note": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true
-            },
-            "gen": {
-              "type": "string",
-              "default": "",
-              "nullable": true
-            },
-            "gh": {
-              "$ref": "#/components/schemas/Algorand.Digest"
-            },
-            "grp": {
-              "$ref": "#/components/schemas/Algorand.Digest"
-            },
-            "lx": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true
-            },
-            "rekey": {
-              "$ref": "#/components/schemas/Algorand.Address"
-            }
-          },
-          "additionalProperties": false
-        },
-        "Algorand.Digest": {
-          "type": "object",
-          "properties": {
-            "bytes": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Algorand.LogicsigSignature": {
-          "type": "object",
-          "properties": {
-            "l": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true
-            },
-            "arg": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "format": "byte"
-              },
-              "nullable": true
-            },
-            "sig": {
-              "$ref": "#/components/schemas/Algorand.Signature"
-            },
-            "msig": {
-              "$ref": "#/components/schemas/Algorand.MultisigSignature"
-            }
-          },
-          "additionalProperties": false
-        },
-        "Algorand.MultisigSignature": {
-          "type": "object",
-          "properties": {
-            "v": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "thr": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "subsig": {
-              "type": "array",
-              "items": {
-                "$ref": "#/components/schemas/Algorand.MultisigSubsig"
-              },
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Algorand.MultisigSubsig": {
-          "type": "object",
-          "properties": {
-            "pk": {
-              "$ref": "#/components/schemas/Org.BouncyCastle.Crypto.Parameters.Ed25519PublicKeyParameters"
-            },
-            "s": {
-              "$ref": "#/components/schemas/Algorand.Signature"
-            }
-          },
-          "additionalProperties": false
-        },
-        "Algorand.ParticipationPublicKey": {
-          "type": "object",
-          "properties": {
-            "bytes": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Algorand.Signature": {
-          "type": "object",
-          "properties": {
-            "bytes": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true,
-              "readOnly": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Algorand.TEALProgram": {
-          "type": "object",
-          "properties": {
-            "bytes": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true,
-              "readOnly": true
-            }
-          },
-          "additionalProperties": false
-        },
-        "Algorand.VRFPublicKey": {
-          "type": "object",
-          "properties": {
-            "bytes": {
-              "type": "string",
-              "format": "byte",
-              "nullable": true
-            }
-          },
-          "additionalProperties": false
-        }
+        "additionalProperties": false
       }
     }
   }
+}

--- a/dotnet_templates/Transactions.json
+++ b/dotnet_templates/Transactions.json
@@ -1,0 +1,983 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+      "title": "AlgodProxy",
+      "version": "v1"
+    },
+    "paths": {
+      "/Algod": {
+        "get": {
+          "tags": [
+            "Algod"
+          ],
+          "responses": {
+            "200": {
+              "description": "Success",
+              "content": {
+                "text/plain": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.SignedTransaction"
+                  }
+                },
+                "application/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.SignedTransaction"
+                  }
+                },
+                "text/json": {
+                  "schema": {
+                    "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.SignedTransaction"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "components": {
+      "schemas": {
+        "Algorand.Address": {
+          "type": "object",
+          "properties": {
+            "bytes": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.AssetParams": {
+          "type": "object",
+          "properties": {
+            "c": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "clawback": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "creator": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "dc": {
+              "maximum": 19,
+              "minimum": 0,
+              "type": "integer",
+              "format": "int64"
+            },
+            "decimals": {
+              "type": "integer",
+              "format": "int64",
+              "writeOnly": true
+            },
+            "df": {
+              "type": "boolean",
+              "default": false,
+              "nullable": true
+            },
+            "default-frozen": {
+              "type": "boolean",
+              "nullable": true,
+              "writeOnly": true
+            },
+            "f": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "freeze": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "m": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "manager": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "am": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true
+            },
+            "metadata-hash": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true,
+              "writeOnly": true
+            },
+            "an": {
+              "type": "string",
+              "nullable": true
+            },
+            "name": {
+              "type": "string",
+              "nullable": true,
+              "writeOnly": true
+            },
+            "name-b64": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true,
+              "writeOnly": true
+            },
+            "r": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "reserve": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "t": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "total": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": true,
+              "writeOnly": true
+            },
+            "un": {
+              "type": "string",
+              "nullable": true
+            },
+            "unit-name": {
+              "type": "string",
+              "nullable": true,
+              "writeOnly": true
+            },
+            "unit-name-b64": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true,
+              "writeOnly": true
+            },
+            "au": {
+              "type": "string",
+              "nullable": true
+            },
+            "url": {
+              "type": "string",
+              "nullable": true,
+              "writeOnly": true
+            },
+            "url-b64": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true,
+              "writeOnly": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.ApplicationCallTransaction": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.Transaction"
+            }
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "nullable": true,
+              "readOnly": true
+            },
+            "apat": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Algorand.Address"
+              },
+              "nullable": true
+            },
+            "apaa": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "byte"
+              },
+              "nullable": true
+            },
+            "apfa": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "nullable": true
+            },
+            "apas": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.ApplicationClearStateTransaction": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
+            }
+          ],
+          "properties": {
+            "apid": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0
+            },
+            "apan": {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.OnCompletion"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.ApplicationCloseOutTransaction": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
+            }
+          ],
+          "properties": {
+            "apid": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "apan": {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.OnCompletion"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.ApplicationCreateTransaction": {
+          "required": [
+            "apap",
+            "apgs",
+            "apls",
+            "apsu"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationNoopTransaction"
+            }
+          ],
+          "properties": {
+            "apap": {
+              "$ref": "#/components/schemas/Algorand.TEALProgram"
+            },
+            "apsu": {
+              "$ref": "#/components/schemas/Algorand.TEALProgram"
+            },
+            "apgs": {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.StateSchema"
+            },
+            "apls": {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.StateSchema"
+            },
+            "apep": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.ApplicationDeleteTransaction": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
+            }
+          ],
+          "properties": {
+            "apid": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "apan": {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.OnCompletion"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.ApplicationNoopTransaction": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
+            }
+          ],
+          "properties": {
+            "apid": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "apan": {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.OnCompletion"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.ApplicationOptInTransaction": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
+            }
+          ],
+          "properties": {
+            "apid": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "apan": {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.OnCompletion"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.ApplicationUpdateTransaction": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
+            }
+          ],
+          "properties": {
+            "apid": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "apan": {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.OnCompletion"
+            },
+            "apap": {
+              "$ref": "#/components/schemas/Algorand.TEALProgram"
+            },
+            "apsu": {
+              "$ref": "#/components/schemas/Algorand.TEALProgram"
+            },
+            "apgs": {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.StateSchema"
+            },
+            "apls": {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.StateSchema"
+            },
+            "apep": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.AssetAcceptTransaction": {
+          "required": [
+            "arcv"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetMovementsTransaction"
+            }
+          ],
+          "properties": {
+            "arcv": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.AssetChangeTransaction": {
+          "required": [
+            "caid"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetConfigurationTransaction"
+            }
+          ],
+          "properties": {
+            "caid": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.AssetClawbackTransaction": {
+          "required": [
+            "aamt",
+            "arcv",
+            "asnd"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetMovementsTransaction"
+            }
+          ],
+          "properties": {
+            "aamt": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0
+            },
+            "asnd": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "arcv": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.AssetConfigurationTransaction": {
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.Transaction"
+            }
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "readOnly": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.AssetCreateTransaction": {
+          "required": [
+            "apar"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetConfigurationTransaction"
+            }
+          ],
+          "properties": {
+            "apar": {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.AssetParams"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.AssetDestroyTransaction": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetChangeTransaction"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.AssetFreezeTransaction": {
+          "required": [
+            "fadd",
+            "faid",
+            "type"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.Transaction"
+            }
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "readOnly": true
+            },
+            "fadd": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "faid": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0
+            },
+            "afrz": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.AssetMovementsTransaction": {
+          "required": [
+            "type",
+            "xaid"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.Transaction"
+            }
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "readOnly": true
+            },
+            "xaid": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.AssetTransferTransaction": {
+          "required": [
+            "aamt",
+            "arcv"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetMovementsTransaction"
+            }
+          ],
+          "properties": {
+            "aamt": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0
+            },
+            "arcv": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "aclose": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.AssetUpdateTransaction": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetChangeTransaction"
+            }
+          ],
+          "properties": {
+            "apar": {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.AssetParams"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.KeyRegisterOfflineTransaction": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.KeyRegistrationTransaction"
+            }
+          ],
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.KeyRegisterOnlineTransaction": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.KeyRegistrationTransaction"
+            }
+          ],
+          "properties": {
+            "votekey": {
+              "$ref": "#/components/schemas/Algorand.ParticipationPublicKey"
+            },
+            "selkey": {
+              "$ref": "#/components/schemas/Algorand.VRFPublicKey"
+            },
+            "votefst": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "votelst": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "votekd": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "nonpart": {
+              "type": "boolean",
+              "default": false,
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.KeyRegistrationTransaction": {
+          "required": [
+            "type"
+          ],
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.Transaction"
+            }
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "readOnly": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.OnCompletion": {
+          "enum": [
+            0,
+            1,
+            2,
+            3,
+            4,
+            5
+          ],
+          "type": "integer",
+          "format": "int32"
+        },
+        "Algorand.Algod.Model.Transactions.PaymentTransaction": {
+          "type": "object",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.Transaction"
+            }
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "nullable": true,
+              "readOnly": true
+            },
+            "amt": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "amount": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": true,
+              "writeOnly": true
+            },
+            "rcv": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "close": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.SignedTransaction": {
+          "type": "object",
+          "properties": {
+            "txn": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCallTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationClearStateTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCloseOutTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationCreateTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationDeleteTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationNoopTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationOptInTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.ApplicationUpdateTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetAcceptTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetChangeTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetClawbackTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetConfigurationTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetCreateTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetDestroyTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetFreezeTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetMovementsTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetTransferTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.AssetUpdateTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.KeyRegisterOfflineTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.KeyRegisterOnlineTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.KeyRegistrationTransaction"
+                },
+                {
+                  "$ref": "#/components/schemas/Algorand.Algod.Model.Transactions.PaymentTransaction"
+                }
+              ],
+              "nullable": true
+            },
+            "sig": {
+              "$ref": "#/components/schemas/Algorand.Signature"
+            },
+            "msig": {
+              "$ref": "#/components/schemas/Algorand.MultisigSignature"
+            },
+            "lsig": {
+              "$ref": "#/components/schemas/Algorand.LogicsigSignature"
+            },
+            "sgnr": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.StateSchema": {
+          "type": "object",
+          "properties": {
+            "nui": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "nbs": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Algod.Model.Transactions.Transaction": {
+          "type": "object",
+          "properties": {
+            "snd": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            },
+            "fee": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "fv": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "lv": {
+              "type": "integer",
+              "format": "int64",
+              "default": 0,
+              "nullable": true
+            },
+            "note": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true
+            },
+            "gen": {
+              "type": "string",
+              "default": "",
+              "nullable": true
+            },
+            "gh": {
+              "$ref": "#/components/schemas/Algorand.Digest"
+            },
+            "grp": {
+              "$ref": "#/components/schemas/Algorand.Digest"
+            },
+            "lx": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true
+            },
+            "rekey": {
+              "$ref": "#/components/schemas/Algorand.Address"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Digest": {
+          "type": "object",
+          "properties": {
+            "bytes": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.LogicsigSignature": {
+          "type": "object",
+          "properties": {
+            "l": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true
+            },
+            "arg": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "byte"
+              },
+              "nullable": true
+            },
+            "sig": {
+              "$ref": "#/components/schemas/Algorand.Signature"
+            },
+            "msig": {
+              "$ref": "#/components/schemas/Algorand.MultisigSignature"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.MultisigSignature": {
+          "type": "object",
+          "properties": {
+            "v": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "thr": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "subsig": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Algorand.MultisigSubsig"
+              },
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.MultisigSubsig": {
+          "type": "object",
+          "properties": {
+            "pk": {
+              "$ref": "#/components/schemas/Org.BouncyCastle.Crypto.Parameters.Ed25519PublicKeyParameters"
+            },
+            "s": {
+              "$ref": "#/components/schemas/Algorand.Signature"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.ParticipationPublicKey": {
+          "type": "object",
+          "properties": {
+            "bytes": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.Signature": {
+          "type": "object",
+          "properties": {
+            "bytes": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true,
+              "readOnly": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.TEALProgram": {
+          "type": "object",
+          "properties": {
+            "bytes": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true,
+              "readOnly": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "Algorand.VRFPublicKey": {
+          "type": "object",
+          "properties": {
+            "bytes": {
+              "type": "string",
+              "format": "byte",
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  }

--- a/dotnet_templates/algod_common_config.properties
+++ b/dotnet_templates/algod_common_config.properties
@@ -1,0 +1,4 @@
+query_skip=Metrics,SwaggerJSON
+query_package=algod
+auth_header=X-Algo-API-Token
+api=common

--- a/dotnet_templates/algod_common_config.properties
+++ b/dotnet_templates/algod_common_config.properties
@@ -1,4 +1,4 @@
 query_skip=Metrics,SwaggerJSON
-query_package=algod
+query_package=CommonApi
 auth_header=X-Algo-API-Token
 api=common

--- a/dotnet_templates/algod_default_config.properties
+++ b/dotnet_templates/algod_default_config.properties
@@ -1,0 +1,4 @@
+query_skip=Metrics,SwaggerJSON
+query_package=algod
+auth_header=X-Algo-API-Token
+api=default

--- a/dotnet_templates/algod_default_config.properties
+++ b/dotnet_templates/algod_default_config.properties
@@ -1,4 +1,4 @@
 query_skip=Metrics,SwaggerJSON
-query_package=algod
+query_package=DefaultApi
 auth_header=X-Algo-API-Token
 api=default

--- a/dotnet_templates/algod_default_config.properties
+++ b/dotnet_templates/algod_default_config.properties
@@ -2,3 +2,4 @@ query_skip=Metrics,SwaggerJSON
 query_package=DefaultApi
 auth_header=X-Algo-API-Token
 api=default
+indexer=false

--- a/dotnet_templates/algod_model_config.properties
+++ b/dotnet_templates/algod_model_config.properties
@@ -1,0 +1,3 @@
+model_skip=
+model_package=models
+namespace=Algorand.Algod.Model

--- a/dotnet_templates/algod_model_config.properties
+++ b/dotnet_templates/algod_model_config.properties
@@ -1,3 +1,3 @@
-model_skip=
+model_skip=Algorand.AssetParams
 model_package=models
 namespace=Algorand.Algod.Model

--- a/dotnet_templates/algod_model_config.properties
+++ b/dotnet_templates/algod_model_config.properties
@@ -1,3 +1,4 @@
 model_skip=Algorand.AssetParams
 model_package=models
 namespace=Algorand.Algod.Model
+indexer=false

--- a/dotnet_templates/algod_private_config.properties
+++ b/dotnet_templates/algod_private_config.properties
@@ -1,4 +1,4 @@
 query_skip=Metrics,SwaggerJSON
-query_package=algod
+query_package=PrivateApi
 auth_header=X-Algo-API-Token
 api=private

--- a/dotnet_templates/algod_private_config.properties
+++ b/dotnet_templates/algod_private_config.properties
@@ -1,4 +1,0 @@
-query_skip=Metrics,SwaggerJSON
-query_package=PrivateApi
-auth_header=X-Algo-API-Token
-api=private

--- a/dotnet_templates/algod_private_config.properties
+++ b/dotnet_templates/algod_private_config.properties
@@ -1,0 +1,4 @@
+query_skip=Metrics,SwaggerJSON
+query_package=algod
+auth_header=X-Algo-API-Token
+api=private

--- a/dotnet_templates/client.vm
+++ b/dotnet_templates/client.vm
@@ -150,7 +150,15 @@ namespace Algorand.Algod
 #foreach( $parm in $q.pathParameters )
               urlBuilder_.Replace("{$parm.propertyName}", System.Uri.EscapeDataString(ConvertToString($str.kebabToCamel($parm.propertyName), System.Globalization.CultureInfo.InvariantCulture)));
 #end
-
+#foreach( $parm in $q.queryParameters )
+              if ($str.kebabToCamel($parm.propertyName) != null)
+              {
+                     urlBuilder_.Append(System.Uri.EscapeDataString("$parm.propertyName") + "=").Append(System.Uri.EscapeDataString(ConvertToString($str.kebabToCamel($parm.propertyName), System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+              }
+#end            
+#if($q.queryParameters.size()>0)
+              urlBuilder_.Length--;
+#end   
               var client_ = _httpClient;
               var disposeClient_ = false;
               try

--- a/dotnet_templates/client.vm
+++ b/dotnet_templates/client.vm
@@ -63,6 +63,7 @@ namespace Algorand.Algod
     using System.Collections.Generic;
     using System.IO;
     using System = global::System;
+    using Newtonsoft.Msgpack;
 
 
     public partial interface I${str.capitalize($propFile.api)}Api
@@ -262,31 +263,57 @@ namespace Algorand.Algod
 
        if (ReadResponseAsString)
        {
-              var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+              string responseText;
+                if (response.Content.Headers.ContentType.MediaType == "application/msgpack")
+                {
+                    using (MessagePackReader reader = new MessagePackReader(await response.Content.ReadAsStreamAsync().ConfigureAwait(false)))
+                    {
+                        responseText = reader.ReadAsString();
+                    }
+                }
+                else
+                {
+                    responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                }
+                
               try
               {
-              var typedBody = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(responseText, JsonSerializerSettings);
-              return new ObjectResponseResult<T>(typedBody, responseText);
+                     var typedBody = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(responseText, JsonSerializerSettings);
+                     return new ObjectResponseResult<T>(typedBody, responseText);
               }
               catch (Newtonsoft.Json.JsonException exception)
               {
-              var message = "Could not deserialize the response body string as " + typeof(T).FullName + ".";
-              throw new ApiException(message, (int)response.StatusCode, responseText, headers, exception);
+                     var message = "Could not deserialize the response body string as " + typeof(T).FullName + ".";
+                     throw new ApiException(message, (int)response.StatusCode, responseText, headers, exception);
               }
        }
        else
        {
-              try
-              {
-              using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
-              using (var streamReader = new System.IO.StreamReader(responseStream))
-              using (var jsonTextReader = new Newtonsoft.Json.JsonTextReader(streamReader))
-              {
-                     var serializer = Newtonsoft.Json.JsonSerializer.Create(JsonSerializerSettings);
-                     var typedBody = serializer.Deserialize<T>(jsonTextReader);
-                     return new ObjectResponseResult<T>(typedBody, string.Empty);
-              }
-              }
+                 try
+                {
+                    if (response.Content.Headers.ContentType.MediaType == "application/msgpack")
+                    {
+                        using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                        using (var reader = new MessagePackReader(responseStream))
+                        {
+                            var serializer = Newtonsoft.Json.JsonSerializer.Create(JsonSerializerSettings);
+                            var typedBody = serializer.Deserialize<T>(reader);
+                            return new ObjectResponseResult<T>(typedBody, string.Empty);
+                        }
+                    }
+                    else
+                    {
+                        using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                        using (var streamReader = new System.IO.StreamReader(responseStream))
+                        using (var jsonTextReader = new Newtonsoft.Json.JsonTextReader(streamReader))
+                        {
+                            var serializer = Newtonsoft.Json.JsonSerializer.Create(JsonSerializerSettings);
+                            var typedBody = serializer.Deserialize<T>(jsonTextReader);
+                            return new ObjectResponseResult<T>(typedBody, string.Empty);
+                        }
+                    }
+                                      
+                }
               catch (Newtonsoft.Json.JsonException exception)
               {
               var message = "Could not deserialize the response body stream as " + typeof(T).FullName + ".";

--- a/dotnet_templates/client.vm
+++ b/dotnet_templates/client.vm
@@ -67,13 +67,14 @@ namespace Algorand.Algod
     public partial interface I${str.capitalize($propFile.api)}Api
     {
 #foreach( $q in $queries )
+#if ($q.api == $propFile.api)
        /// <summary>$q.description</summary>
 #foreach( $parm in $q.allParams )
        /// <param name="$parm.propertyName">$parm.doc</param>
 #end
-       /// <exception cref="ApiException">A server side error occurred.</exception>
+       /// <exception cref="ApiException<ErrorResponse>">A server side error occurred.</exception>
        System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q));
-       
+#end     
 #end
     }
 
@@ -103,7 +104,7 @@ namespace Algorand.Algod
        partial void ProcessResponse(System.Net.Http.HttpClient client, System.Net.Http.HttpResponseMessage response);
 
 #foreach( $q in $queries )
-
+#if ($q.api == $propFile.api)
        
 
        /// <summary>$q.description</summary>
@@ -121,7 +122,7 @@ namespace Algorand.Algod
        /// <param name="$parm.propertyName">$parm.doc</param>
 #end
        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-       /// <exception cref="ApiException">A server side error occurred.</exception>
+       /// <exception cref="ApiException<ErrorResponse>">A server side error occurred.</exception>
        public System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q), System.Threading.CancellationToken cancellationToken)
        {
 #foreach( $parm in $q.allParams )
@@ -215,7 +216,7 @@ namespace Algorand.Algod
        }
 
 
-
+#end
 #end
        private string ConvertToString(object value, System.Globalization.CultureInfo cultureInfo)
        {

--- a/dotnet_templates/client.vm
+++ b/dotnet_templates/client.vm
@@ -30,13 +30,13 @@ $sep#queryParamToArgDef($p)
 #macro( queryToClientArgList $query )
 #set( $sep = "" )
 #foreach( $p in $query.pathParameters )
-$sep$p.propertyName#set( $sep = ", " )
+$sep$str.kebabToCamel($p.propertyName)#set( $sep = ", " )
 #end
 #foreach( $p in $query.bodyParameters )
-$sep$p.propertyName#set( $sep = ", " )
+$sep$str.kebabToCamel($p.propertyName)#set( $sep = ", " )
 #end
 #foreach( $p in $query.queryParameters )
-$sep$p.propertyName#set( $sep = ", " )
+$sep$str.kebabToCamel($p.propertyName)#set( $sep = ", " )
 #end
 #end
 ## Given a query print the struct initialization.
@@ -59,6 +59,7 @@ namespace Algorand.Algod
 {
     using Algorand.Utils;
     using Algorand.Algod.Model;
+    using Algorand.Algod.Model.Transactions;
     using System.Collections.Generic;
     using System.IO;
     using System = global::System;
@@ -68,12 +69,20 @@ namespace Algorand.Algod
     {
 #foreach( $q in $queries )
 #if ($q.api == $propFile.api)
-       /// <summary>$q.description</summary>
+       /// <summary>$str.formatDoc($q.description, "/// ")
+       /// </summary>
 #foreach( $parm in $q.allParams )
        /// <param name="$parm.propertyName">$parm.doc</param>
 #end
        /// <exception cref="ApiException<ErrorResponse>">A server side error occurred.</exception>
        System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q));
+
+#foreach( $parm in $q.allParams )
+       /// <param name="$parm.propertyName">$parm.doc</param>
+#end
+       /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+       System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q)${sep}System.Threading.CancellationToken cancellationToken);
+
 #end     
 #end
     }
@@ -107,27 +116,29 @@ namespace Algorand.Algod
 #if ($q.api == $propFile.api)
        
 
-       /// <summary>$q.description</summary>
+       /// <summary>$str.formatDoc($q.description, "/// ")
+       /// </summary>
 #foreach( $parm in $q.allParams )
        /// <param name="$parm.propertyName">$parm.doc</param>
 #end
        /// <exception cref="ApiException">A server side error occurred.</exception>
        public System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q))
        {
-              return #mapQueryName($q.Name)Async(#queryToClientArgList($q),System.Threading.CancellationToken.None)
+              return #mapQueryName($q.Name)Async(#queryToClientArgList($q)${sep}System.Threading.CancellationToken.None);
        }
 
-       /// <summary>$q.description</summary>
+       /// <summary>>$str.formatDoc($q.description, "/// ")
+       /// </summary>
 #foreach( $parm in $q.allParams )
        /// <param name="$parm.propertyName">$parm.doc</param>
 #end
        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
        /// <exception cref="ApiException<ErrorResponse>">A server side error occurred.</exception>
-       public System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q), System.Threading.CancellationToken cancellationToken)
+       public async System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q)${sep}System.Threading.CancellationToken cancellationToken)
        {
 #foreach( $parm in $q.allParams )
 #if($parm.Required=="true")
-              if ($parm.propertyName == null) throw new System.ArgumentNullException("$parm.propertyName");
+              if ($str.kebabToCamel($parm.propertyName) == null) throw new System.ArgumentNullException("$str.kebabToCamel($parm.propertyName)");
 #end
 #end
               var urlBuilder_ = new System.Text.StringBuilder();
@@ -137,7 +148,7 @@ namespace Algorand.Algod
               urlBuilder_.Append("$q.path");
 #end              
 #foreach( $parm in $q.pathParameters )
-              urlBuilder_.Replace("{$parm.propertyName}", System.Uri.EscapeDataString(ConvertToString($parm.propertyName, System.Globalization.CultureInfo.InvariantCulture)));
+              urlBuilder_.Replace("{$parm.propertyName}", System.Uri.EscapeDataString(ConvertToString($str.kebabToCamel($parm.propertyName), System.Globalization.CultureInfo.InvariantCulture)));
 #end
 
               var client_ = _httpClient;
@@ -149,7 +160,7 @@ namespace Algorand.Algod
                      request_.Method = new System.Net.Http.HttpMethod("$q.method.toUpperCase()");
                      request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
 #if($q.bodyParameters.size()>0)
-#if($q.Name=="RawTransaction" || $q.Name=="Dryrun") 
+#if($q.Name=="RawTransaction" || $q.Name=="TealDryrun") 
                      System.Net.Http.ByteArrayContent content_ = new System.Net.Http.ByteArrayContent(Encoder.EncodeToMsgPackOrdered($q.bodyParameters.get(0).propertyName));
                      content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/msgpack");
 #else
@@ -218,6 +229,64 @@ namespace Algorand.Algod
 
 #end
 #end
+
+       protected struct ObjectResponseResult<T>
+       {
+       public ObjectResponseResult(T responseObject, string responseText)
+       {
+              this.Object = responseObject;
+              this.Text = responseText;
+       }
+
+       public T Object { get; }
+
+       public string Text { get; }
+       }
+
+       public bool ReadResponseAsString { get; set; }
+
+       protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> ReadObjectResponseAsync<T>(System.Net.Http.HttpResponseMessage response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Threading.CancellationToken cancellationToken)
+       {
+       if (response == null || response.Content == null)
+       {
+              return new ObjectResponseResult<T>(default(T), string.Empty);
+       }
+
+       if (ReadResponseAsString)
+       {
+              var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+              try
+              {
+              var typedBody = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(responseText, JsonSerializerSettings);
+              return new ObjectResponseResult<T>(typedBody, responseText);
+              }
+              catch (Newtonsoft.Json.JsonException exception)
+              {
+              var message = "Could not deserialize the response body string as " + typeof(T).FullName + ".";
+              throw new ApiException(message, (int)response.StatusCode, responseText, headers, exception);
+              }
+       }
+       else
+       {
+              try
+              {
+              using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+              using (var streamReader = new System.IO.StreamReader(responseStream))
+              using (var jsonTextReader = new Newtonsoft.Json.JsonTextReader(streamReader))
+              {
+                     var serializer = Newtonsoft.Json.JsonSerializer.Create(JsonSerializerSettings);
+                     var typedBody = serializer.Deserialize<T>(jsonTextReader);
+                     return new ObjectResponseResult<T>(typedBody, string.Empty);
+              }
+              }
+              catch (Newtonsoft.Json.JsonException exception)
+              {
+              var message = "Could not deserialize the response body stream as " + typeof(T).FullName + ".";
+              throw new ApiException(message, (int)response.StatusCode, string.Empty, headers, exception);
+              }
+       }
+       }
+
        private string ConvertToString(object value, System.Globalization.CultureInfo cultureInfo)
        {
               if (value == null)
@@ -261,7 +330,7 @@ namespace Algorand.Algod
 
               var result = System.Convert.ToString(value, cultureInfo);
               return result == null ? "" : result;
-              }
+              
        }
 
     }

--- a/dotnet_templates/client.vm
+++ b/dotnet_templates/client.vm
@@ -1,0 +1,268 @@
+#set( $skip = $propFile.query_skip.split(",") )
+#parse("common_macros.vm")
+## Given a query print the arg list to the function.
+#macro( queryToClientArgs $query )
+#set( $sep = "" )
+#foreach( $p in $query.pathParameters )
+$sep#pathParamToArgDef($p)
+#set( $sep = ", " )
+#end
+#foreach( $p in $query.bodyParameters )
+$sep#bodyParamToArgDef($p)
+#set( $sep = ", " )
+#end
+#foreach( $p in $query.queryParameters )
+$sep#queryParamToArgDef($p)  
+#set( $sep = ", " )
+#end
+#end
+## Given a query print the struct initialization.
+#macro( queryToStructInit $query )
+&${queryType}{c: c##
+#foreach( $p in $query.pathParameters )
+, $str.kebabToCamel($p.propertyName): $str.kebabToCamel($p.propertyName)##
+#end
+#foreach( $p in $query.bodyParameters )
+, $str.kebabToCamel($p.propertyName): $str.kebabToCamel($p.propertyName)##
+#end
+}
+#end
+#macro( queryToClientArgList $query )
+#set( $sep = "" )
+#foreach( $p in $query.pathParameters )
+$sep$p.propertyName#set( $sep = ", " )
+#end
+#foreach( $p in $query.bodyParameters )
+$sep$p.propertyName#set( $sep = ", " )
+#end
+#foreach( $p in $query.queryParameters )
+$sep$p.propertyName#set( $sep = ", " )
+#end
+#end
+## Given a query print the struct initialization.
+#macro( queryToStructInit $query )
+&${queryType}{c: c##
+#foreach( $p in $query.pathParameters )
+, $str.kebabToCamel($p.propertyName): $str.kebabToCamel($p.propertyName)##
+#end
+#foreach( $p in $query.bodyParameters )
+, $str.kebabToCamel($p.propertyName): $str.kebabToCamel($p.propertyName)##
+#end
+}
+#end
+#macro(mapQueryName $queryName)
+#if ($queryName=="RawTransaction")
+Transactions#else
+$queryName#end
+#end
+namespace Algorand.Algod
+{
+    using Algorand.Utils;
+    using Algorand.Algod.Model;
+    using System.Collections.Generic;
+    using System.IO;
+    using System = global::System;
+
+
+    public partial interface I${str.capitalize($propFile.api)}Api
+    {
+#foreach( $q in $queries )
+       /// <summary>$q.description</summary>
+#foreach( $parm in $q.allParams )
+       /// <param name="$parm.propertyName">$parm.doc</param>
+#end
+       /// <exception cref="ApiException">A server side error occurred.</exception>
+       System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q));
+       
+#end
+    }
+
+    public partial class ${str.capitalize($propFile.api)}Api : I${str.capitalize($propFile.api)}Api
+    {
+       private System.Net.Http.HttpClient _httpClient;
+       private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings;
+
+       public ${str.capitalize($propFile.api)}Api(System.Net.Http.HttpClient httpClient)
+       {
+              _httpClient = httpClient;
+              _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings);
+       }
+       
+       private Newtonsoft.Json.JsonSerializerSettings CreateSerializerSettings()
+       {
+              var settings = new Newtonsoft.Json.JsonSerializerSettings();
+              UpdateJsonSerializerSettings(settings);
+              return settings;
+       }  
+
+       protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
+
+       partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
+       partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
+       partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
+       partial void ProcessResponse(System.Net.Http.HttpClient client, System.Net.Http.HttpResponseMessage response);
+
+#foreach( $q in $queries )
+
+       
+
+       /// <summary>$q.description</summary>
+#foreach( $parm in $q.allParams )
+       /// <param name="$parm.propertyName">$parm.doc</param>
+#end
+       /// <exception cref="ApiException">A server side error occurred.</exception>
+       public System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q))
+       {
+              return #mapQueryName($q.Name)Async(#queryToClientArgList($q),System.Threading.CancellationToken.None)
+       }
+
+       /// <summary>$q.description</summary>
+#foreach( $parm in $q.allParams )
+       /// <param name="$parm.propertyName">$parm.doc</param>
+#end
+       /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+       /// <exception cref="ApiException">A server side error occurred.</exception>
+       public System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q), System.Threading.CancellationToken cancellationToken)
+       {
+#foreach( $parm in $q.allParams )
+#if($parm.Required=="true")
+              if ($parm.propertyName == null) throw new System.ArgumentNullException("$parm.propertyName");
+#end
+#end
+              var urlBuilder_ = new System.Text.StringBuilder();
+#if($q.queryParameters.size()>0)
+              urlBuilder_.Append("$q.path?");
+#else              
+              urlBuilder_.Append("$q.path");
+#end              
+#foreach( $parm in $q.pathParameters )
+              urlBuilder_.Replace("{$parm.propertyName}", System.Uri.EscapeDataString(ConvertToString($parm.propertyName, System.Globalization.CultureInfo.InvariantCulture)));
+#end
+
+              var client_ = _httpClient;
+              var disposeClient_ = false;
+              try
+              {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                     request_.Method = new System.Net.Http.HttpMethod("$q.method.toUpperCase()");
+                     request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+#if($q.bodyParameters.size()>0)
+#if($q.Name=="RawTransaction" || $q.Name=="Dryrun") 
+                     System.Net.Http.ByteArrayContent content_ = new System.Net.Http.ByteArrayContent(Encoder.EncodeToMsgPackOrdered($q.bodyParameters.get(0).propertyName));
+                     content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/msgpack");
+#else
+                     var content_ = new System.Net.Http.StreamContent(source);
+                     content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("text/plain");
+#end
+                     request_.Content = content_;
+#end
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<#returnType($q)>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        //Algorand Generator cannot distinguish between response codes
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ErrorResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new ApiException<ErrorResponse>("Error", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+
+       }
+
+
+
+#end
+       private string ConvertToString(object value, System.Globalization.CultureInfo cultureInfo)
+       {
+              if (value == null)
+              {
+                     return "";
+              }
+
+              if (value is System.Enum)
+              {
+                     var name = System.Enum.GetName(value.GetType(), value);
+                     if (name != null)
+                     {
+                     var field = System.Reflection.IntrospectionExtensions.GetTypeInfo(value.GetType()).GetDeclaredField(name);
+                     if (field != null)
+                     {
+                            var attribute = System.Reflection.CustomAttributeExtensions.GetCustomAttribute(field, typeof(System.Runtime.Serialization.EnumMemberAttribute))
+                            as System.Runtime.Serialization.EnumMemberAttribute;
+                            if (attribute != null)
+                            {
+                            return attribute.Value != null ? attribute.Value : name;
+                            }
+                     }
+
+                     var converted = System.Convert.ToString(System.Convert.ChangeType(value, System.Enum.GetUnderlyingType(value.GetType()), cultureInfo));
+                     return converted == null ? string.Empty : converted;
+                     }
+              }
+              else if (value is bool)
+              {
+                     return System.Convert.ToString((bool)value, cultureInfo).ToLowerInvariant();
+              }
+              else if (value is byte[])
+              {
+                     return System.Convert.ToBase64String((byte[])value);
+              }
+              else if (value.GetType().IsArray)
+              {
+                     var array = System.Linq.Enumerable.OfType<object>((System.Array)value);
+                     return string.Join(",", System.Linq.Enumerable.Select(array, o => ConvertToString(o, cultureInfo)));
+              }
+
+              var result = System.Convert.ToString(value, cultureInfo);
+              return result == null ? "" : result;
+              }
+       }
+
+    }
+
+}

--- a/dotnet_templates/client.vm
+++ b/dotnet_templates/client.vm
@@ -16,6 +16,18 @@ $sep#queryParamToArgDef($p)
 #set( $sep = ", " )
 #end
 #end
+## Given a query print the arg list to the function.
+#macro( queryToClientArgsFixedSep $query )
+#foreach( $p in $query.pathParameters )
+,#pathParamToArgDef($p)
+#end
+#foreach( $p in $query.bodyParameters )
+,#bodyParamToArgDef($p)
+#end
+#foreach( $p in $query.queryParameters )
+,#queryParamToArgDef($p)
+#end
+#end
 ## Given a query print the struct initialization.
 #macro( queryToStructInit $query )
 &${queryType}{c: c##
@@ -27,6 +39,7 @@ $sep#queryParamToArgDef($p)
 #end
 }
 #end
+## Arg list for a call
 #macro( queryToClientArgList $query )
 #set( $sep = "" )
 #foreach( $p in $query.pathParameters )
@@ -37,6 +50,18 @@ $sep$str.kebabToCamel($p.propertyName)#set( $sep = ", " )
 #end
 #foreach( $p in $query.queryParameters )
 $sep$str.kebabToCamel($p.propertyName)#set( $sep = ", " )
+#end
+#end
+## Arg list for a call
+#macro( queryToClientArgListFixedSep $query )
+#foreach( $p in $query.pathParameters )
+,$str.kebabToCamel($p.propertyName)#set( $sep = ", " )
+#end
+#foreach( $p in $query.bodyParameters )
+,$str.kebabToCamel($p.propertyName)#set( $sep = ", " )
+#end
+#foreach( $p in $query.queryParameters )
+,$str.kebabToCamel($p.propertyName)#set( $sep = ", " )
 #end
 #end
 ## Given a query print the struct initialization.
@@ -55,11 +80,17 @@ $sep$str.kebabToCamel($p.propertyName)#set( $sep = ", " )
 Transactions#else
 $queryName#end
 #end
+#if($propFile.indexer)
+namespace Algorand.Indexer
+{
+    using Algorand.Indexer.Model;
+#else
 namespace Algorand.Algod
 {
-    using Algorand.Utils;
     using Algorand.Algod.Model;
     using Algorand.Algod.Model.Transactions;
+#end
+    using Algorand.Utils;
     using System.Collections.Generic;
     using System.IO;
     using System = global::System;
@@ -73,16 +104,16 @@ namespace Algorand.Algod
        /// <summary>$str.formatDoc($q.description, "/// ")
        /// </summary>
 #foreach( $parm in $q.allParams )
-       /// <param name="$parm.propertyName">$parm.doc</param>
+       /// <param name="$parm.propertyName">$str.formatDoc($parm.doc, "/// ")</param>
 #end
        /// <exception cref="ApiException<ErrorResponse>">A server side error occurred.</exception>
        System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q));
 
 #foreach( $parm in $q.allParams )
-       /// <param name="$parm.propertyName">$parm.doc</param>
+       /// <param name="$parm.propertyName">$str.formatDoc($parm.doc, "/// ")</param>
 #end
        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
-       System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q)${sep}System.Threading.CancellationToken cancellationToken);
+       System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(System.Threading.CancellationToken cancellationToken#queryToClientArgsFixedSep($q));
 
 #end     
 #end
@@ -120,22 +151,22 @@ namespace Algorand.Algod
        /// <summary>$str.formatDoc($q.description, "/// ")
        /// </summary>
 #foreach( $parm in $q.allParams )
-       /// <param name="$parm.propertyName">$parm.doc</param>
+       /// <param name="$parm.propertyName">$str.formatDoc($parm.doc, "/// ")</param>
 #end
        /// <exception cref="ApiException">A server side error occurred.</exception>
        public System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q))
        {
-              return #mapQueryName($q.Name)Async(#queryToClientArgList($q)${sep}System.Threading.CancellationToken.None);
+              return #mapQueryName($q.Name)Async(System.Threading.CancellationToken.None#queryToClientArgListFixedSep($q));
        }
 
        /// <summary>>$str.formatDoc($q.description, "/// ")
        /// </summary>
 #foreach( $parm in $q.allParams )
-       /// <param name="$parm.propertyName">$parm.doc</param>
+       /// <param name="$parm.propertyName">$str.formatDoc($parm.doc, "/// ")</param>
 #end
        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
        /// <exception cref="ApiException<ErrorResponse>">A server side error occurred.</exception>
-       public async System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(#queryToClientArgs($q)${sep}System.Threading.CancellationToken cancellationToken)
+       public async System.Threading.Tasks.Task<#returnType($q)> #mapQueryName($q.Name)Async(System.Threading.CancellationToken cancellationToken#queryToClientArgsFixedSep($q))
        {
 #foreach( $parm in $q.allParams )
 #if($parm.Required=="true")
@@ -182,7 +213,7 @@ namespace Algorand.Algod
                     PrepareRequest(client_, request_, urlBuilder_);
 
                     var url_ = urlBuilder_.ToString();
-                    if (url_.StartsWith("/")) { url_ = url_.Remove(0); }
+                    if (url_.StartsWith("/")) { url_ = url_.Remove(0,1); }
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
 
                     PrepareRequest(client_, request_, url_);

--- a/dotnet_templates/client.vm
+++ b/dotnet_templates/client.vm
@@ -182,6 +182,7 @@ namespace Algorand.Algod
                     PrepareRequest(client_, request_, urlBuilder_);
 
                     var url_ = urlBuilder_.ToString();
+                    if (url_.StartsWith("/")) { url_ = url_.Remove(0); }
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
 
                     PrepareRequest(client_, request_, url_);

--- a/dotnet_templates/client_filename.vm
+++ b/dotnet_templates/client_filename.vm
@@ -1,1 +1,1 @@
-${propFile.query_package}.go
+${propFile.query_package}.cs

--- a/dotnet_templates/client_filename.vm
+++ b/dotnet_templates/client_filename.vm
@@ -1,0 +1,1 @@
+${propFile.query_package}.go

--- a/dotnet_templates/common_config.properties
+++ b/dotnet_templates/common_config.properties
@@ -1,2 +1,0 @@
-model_skip=Algorand.Address
-model_package=models

--- a/dotnet_templates/common_config.properties
+++ b/dotnet_templates/common_config.properties
@@ -1,0 +1,5 @@
+# skip all the hand generated stuff for now.
+# todo gradually remove the skipped stuff.
+# cat responsemodels.go |grep "^type"|cut -d' ' -f2|paste -s -d','
+model_skip=
+model_package=models

--- a/dotnet_templates/common_config.properties
+++ b/dotnet_templates/common_config.properties
@@ -1,5 +1,2 @@
-# skip all the hand generated stuff for now.
-# todo gradually remove the skipped stuff.
-# cat responsemodels.go |grep "^type"|cut -d' ' -f2|paste -s -d','
-model_skip=
+model_skip=Algorand.Address
 model_package=models

--- a/dotnet_templates/common_macros.vm
+++ b/dotnet_templates/common_macros.vm
@@ -1,0 +1,89 @@
+#macro ( returnType $query )##
+#if ( ${query.returnType} == "String" )string#elseif 
+(${query.returnType} == "PendingTransactionResponse")IReturnableTransaction#elseif (${query.returnType} == "PendingTransactionsResponse")PendingTransactions#elseif 
+(${query.returnType} == "BlockResponse")CertifiedBlock#else$query.returnType#end
+#end
+
+
+
+
+#macro ( typeConverter $prop $setter)
+#if ( $prop.algorandFormat == "SignedTransaction" )
+#set( $propType = "SignedTransaction" )
+#elseif ( $prop.algorandFormat == "Address" )
+#set( $propType = "Address" )
+#elseif ( $prop.algorandFormat == "TEALProgram" )
+#set( $propType = "TEALProgram" )
+#elseif ( $prop.algorandFormat == "BlockHeader" )
+#set( $propType = "Block" )
+#elseif ( $prop.type == "integer" )
+#set( $propType = "ulong" )
+#elseif( $prop.type == "binary" )
+#set( $propType = "byte[]" )
+#elseif( $prop.type == "boolean" )
+#set( $propType = "bool" )
+#elseif ($prop.arrayType && $prop.format == "byte")
+#set( $propType = "byte[]" )
+#elseif ($prop.type == "string" && $prop.format == "byte")
+#set( $propType = "byte[]" )
+#elseif( $prop.type == "string" && $setter == "true" && $prop.propertyName=="rawtxn")
+#set( $propType = "List<SignedTransaction>" )
+#elseif( $prop.type == "string" && $setter == "true")
+#set( $propType = "System.IO.Stream" )
+#elseif( $prop.type == "string" || $prop.arrayType == "string" )
+#set( $propType = "string" )
+#elseif( $prop.type == "object" )
+#set( $propType = "byte[]" )
+#elseif( $prop.type == "address" )
+#set( $propType = "Address" )
+#elseif( $prop.type == "PendingTransactionResponse" )
+#set( $propType = "ReturnedTransaction" )
+#elseif( $prop.arrayType && $prop.arrayType != "")
+#set( $propType = $prop.arrayType )
+#elseif( $prop.refType  && $prop.refType != "")
+#set( $propType = $prop.refType )
+#else
+#set( $propType = $prop.type )
+#end
+#end
+
+#macro ( oapiToCSharp $param $setter )##
+#if ( $param.algorandFormat == "RFC3339 String" )
+string##
+#elseif ( $param.algorandFormat == "BlockHeader" )
+types.Block
+#elseif( $setter && ($param.algorandFormat == "base64" || $param.type == "binary" || $param.format == "binary" ) )
+[]byte##
+#elseif( $param.type == "binary" )
+string##
+#elseif ( $param.type == "integer" )
+uint64##
+#elseif ( $param.type == "string" )
+string##
+#elseif ( $param.type == "boolean" )
+bool##
+#elseif( $param.arrayType == "string" )
+[]string##
+#elseif ( $!param.refType )
+models.${param.refType}##
+#else
+UNHANDLED TYPE
+- ref: $!param.refType
+- type: $!param.type
+- array type: $!param.arrayType
+- algorand format: $!param.algorandFormat
+- format: $!param.format
+##$unknown.type ## force a template failure with an unknown type
+#end
+#end
+
+
+
+#macro ( pathParamToArgDef $param )#typeConverter($param, false)$propType $str.kebabToCamel($param.propertyName)#end
+
+#macro ( queryParamToArgDef $param )
+#if ($param.propertyName=="format") Format? format#else
+#typeConverter($param, false)$propType? $str.kebabToCamel($param.propertyName)#end
+#end
+
+#macro ( bodyParamToArgDef $param )#typeConverter($param, true)$propType $str.kebabToCamel($param.propertyName)#end

--- a/dotnet_templates/common_macros.vm
+++ b/dotnet_templates/common_macros.vm
@@ -83,7 +83,7 @@ UNHANDLED TYPE
 
 #macro ( queryParamToArgDef $param )
 #if ($param.propertyName=="format") Format? format#else
-#typeConverter($param, false)$propType? $str.kebabToCamel($param.propertyName)#end
+#typeConverter($param, false)$propType? $str.kebabToCamel($param.propertyName)=null#end
 #end
 
 #macro ( bodyParamToArgDef $param )#typeConverter($param, true)$propType $str.kebabToCamel($param.propertyName)#end

--- a/dotnet_templates/indexer_common_config.properties
+++ b/dotnet_templates/indexer_common_config.properties
@@ -1,5 +1,5 @@
-query_skip=Metrics,SwaggerJSON
+query_skip=
 query_package=CommonApi
 auth_header=X-Algo-API-Token
 api=common
-indexer=false
+indexer=true

--- a/dotnet_templates/indexer_lookup_config.properties
+++ b/dotnet_templates/indexer_lookup_config.properties
@@ -1,0 +1,5 @@
+query_skip=
+query_package=LookupApi
+auth_header=X-Algo-API-Token
+api=lookup
+indexer=true

--- a/dotnet_templates/indexer_model_config.properties
+++ b/dotnet_templates/indexer_model_config.properties
@@ -1,0 +1,4 @@
+model_skip=
+model_package=models
+namespace=Algorand.Indexer.Model
+indexer=true

--- a/dotnet_templates/indexer_search_config.properties
+++ b/dotnet_templates/indexer_search_config.properties
@@ -1,0 +1,5 @@
+query_skip=
+query_package=SearchApi
+auth_header=X-Algo-API-Token
+api=search
+indexer=true

--- a/dotnet_templates/model.vm
+++ b/dotnet_templates/model.vm
@@ -1,0 +1,63 @@
+namespace Algorand.Algod.Model
+{
+
+    using System = global::System;
+
+    public partial class $def.name {
+    #foreach( $prop in $props )
+    #if( $prop.required)
+    
+        [Newtonsoft.Json.JsonProperty("$prop.propertyName", Required = Newtonsoft.Json.Required.Always)]
+        [System.ComponentModel.DataAnnotations.Required]
+    #else
+        [Newtonsoft.Json.JsonProperty("top-transactions", Required = Newtonsoft.Json.Required.Default,  NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+    #end
+    #set( $propName = $str.kebabToUpperCamel($prop.propertyName) )
+    #if ( $prop.algorandFormat == "SignedTransaction" )
+        #set( $propType = "SignedTransaction" )
+    #elseif ( $prop.algorandFormat == "Address" )
+        #set( $propType = "Address" )
+    #elseif ( $prop.algorandFormat == "TEALProgram" )
+        #set( $propType = "TEALProgram" )
+    #elseif ( $prop.algorandFormat == "BlockHeader" )
+        #set( $propType = "Block" )    
+    #elseif ( $prop.type == "integer" )
+        #set( $propType = "uint64" )
+    #elseif( $prop.type == "binary" )
+        #set( $propType = "byte[]" )
+    #elseif( $prop.type == "boolean" )
+        #set( $propType = "bool" )   
+    #elseif ($prop.arrayType && $prop.format == "byte")
+        #set( $propType = "byte[]" )   
+    #elseif ($prop.type == "string" && $prop.format == "byte")
+        #set( $propType = "byte[]" ) 
+    #elseif( $prop.type == "string" || $prop.arrayType == "string" )
+        #set( $propType = "string" )             
+    #elseif( $prop.type == "object" )
+        #set( $propType = "byte[]" )    
+    #elseif( $prop.type == "address" )
+        #set( $propType = "Address" )
+    #elseif( $prop.arrayType  && $prop.arrayType != "")
+        #set( $propType = $prop.arrayType )
+    #elseif( $prop.refType  && $prop.refType != "")
+        #set( $propType = $prop.refType )    
+    #else
+        UNHANDLED TYPE
+    - ref: $!prop.refType
+    - type: $!prop.type
+    - array type: $!prop.arrayType
+    - algorand format: $!prop.algorandFormat
+    - format: $!prop.format
+    $unknown.type ## force a template failure with an unknown type
+    #end
+    #if( $prop.arrayType && $prop.arrayType != "")
+        public System.Collections.Generic.ICollection<$propType> $propName {get;set;} = new System.Collections.ObjectModel.Collection<$propType>();
+    #else
+        public $propType $propName {get;set;}
+    #end
+    #end
+        
+    }
+
+
+}

--- a/dotnet_templates/model.vm
+++ b/dotnet_templates/model.vm
@@ -4,7 +4,11 @@ namespace $propFile.namespace
 
     using System = global::System;
 
-    public partial class $def.name {
+#if($!def.parentType && $!def.parentType != "" )
+    public partial class $def.name : $!def.parentType{
+#else
+    public partial class $def.name
+#end
     #foreach( $prop in $props )
     #if( $prop.required)
     

--- a/dotnet_templates/model.vm
+++ b/dotnet_templates/model.vm
@@ -2,75 +2,102 @@
 namespace $propFile.namespace
 {
 
-    using System = global::System;
+using System = global::System;
+#set($accessibility="public")
+#set($className=$def.name)
+#if($className=="PendingTransactionResponse")
+#set($className="ReturnedTransaction")
+#set($accessibility="internal")
+#elseif($className=="PendingTransactionsResponse")
+#set($className="PendingTransactions")
+#elseif($className=="BlockResponse")
+#set($className="CertifiedBlock")
+#end
+
 
 #if($!def.parentType && $!def.parentType != "" )
-    public partial class $def.name : $!def.parentType{
+public partial class $className : $!def.parentType{
 #else
-    public partial class $def.name
+public partial class $className{
 #end
-    #foreach( $prop in $props )
-    #if( $prop.required)
+#foreach( $prop in $props )
+#if( $prop.required)
+
+    [Newtonsoft.Json.JsonProperty("$prop.propertyName", Required = Newtonsoft.Json.Required.Always)]
+    [System.ComponentModel.DataAnnotations.Required]
+#else
+    [Newtonsoft.Json.JsonProperty("$prop.propertyName", Required = Newtonsoft.Json.Required.Default,  NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+#end
+#if (!$prop.algorandLongNameAlias || $prop.algorandLongNameAlias=="")
+    #set( $propName = $str.kebabToUpperCamel($prop.propertyName) )
+#else
+    #set( $propName = $str.kebabToUpperCamel($prop.algorandLongNameAlias) )
+#end
+#if ($className == "Account" && $prop.propertyName=="address") 
+    #set( $propType = "Address" )
+#elseif ( $prop.type == "PendingTransactionResponse" )
+    #set( $propType = "IReturnableTransaction" )
+#elseif ( $prop.algorandFormat == "SignedTransaction" )
+    #set( $propType = "SignedTransaction" )
+#elseif ( $prop.algorandFormat == "Transaction" )
+    #set( $propType = "Transaction" )
+#elseif ( $prop.algorandFormat == "Address" )
+    #set( $propType = "Address" )
+#elseif ( $prop.algorandFormat == "TEALProgram" )
+    #set( $propType = "TEALProgram" )
+#elseif ( $prop.algorandFormat == "BlockHeader" )
+    #set( $propType = "Block" )    
+#elseif ( $prop.type == "integer" )
+#if($prop.required)
+    #set( $propType = "ulong" )
+#else
+    #set( $propType = "ulong?" )
+#end
+#elseif( $prop.type == "binary" )
+    #set( $propType = "byte[]" )
+#elseif( $prop.type == "boolean" )
+#if($prop.required)
+    #set( $propType = "bool" )   
+#else
+    #set( $propType = "bool?" )
+#end
+#elseif ($prop.arrayType && $prop.arrayType=="PendingTransactionResponse")
+  #set( $propType = "IReturnableTransaction" )   
+#elseif ($prop.arrayType && $prop.format == "byte")
+    #set( $propType = "byte[]" )   
+#elseif ($prop.type == "string" && $prop.format == "byte")
+    #set( $propType = "byte[]" ) 
+#elseif( $prop.type == "string" || $prop.arrayType == "string" )
+    #set( $propType = "string" )             
+#elseif( $prop.type == "object" )
+    #set( $propType = "byte[]" )    
+#elseif( $prop.type == "address" )
+    #set( $propType = "Address" )
+#elseif( $prop.arrayType  && $prop.arrayType != "")
+    #set( $propType = $prop.arrayType )
+#elseif( $prop.refType  && $prop.refType != "")
+    #set( $propType = $prop.refType )    
+#else
+    UNHANDLED TYPE **
+- name: $!propName
+- ref: $!prop.refType
+- type: $!prop.type
+- array type: $!prop.arrayType
+- algorand format: $!prop.algorandFormat
+- format: $!prop.format
+- prop: $prop
+$unknown.type ## force a template failure with an unknown type
+#end
+#if( $prop.arrayType && $prop.arrayType != "")
+    public System.Collections.Generic.ICollection<$propType> $propName {get;set;} = new System.Collections.ObjectModel.Collection<$propType>();
+
+#else
+    public $propType $propName {get;set;}
+
+#end
+#end
     
-        [Newtonsoft.Json.JsonProperty("$prop.propertyName", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
-    #else
-        [Newtonsoft.Json.JsonProperty("$prop.propertyName", Required = Newtonsoft.Json.Required.Default,  NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-    #end
-    #if (!$prop.algorandLongNameAlias || $prop.algorandLongNameAlias=="")
-        #set( $propName = $str.kebabToUpperCamel($prop.propertyName) )
-    #else
-        #set( $propName = $str.kebabToUpperCamel($prop.algorandLongNameAlias) )
-    #end
-    #if ( $prop.algorandFormat == "SignedTransaction" )
-        #set( $propType = "SignedTransaction" )
-    #elseif ( $prop.algorandFormat == "Transaction" )
-        #set( $propType = "Transaction" )
-    #elseif ( $prop.algorandFormat == "Address" )
-        #set( $propType = "Address" )
-    #elseif ( $prop.algorandFormat == "TEALProgram" )
-        #set( $propType = "TEALProgram" )
-    #elseif ( $prop.algorandFormat == "BlockHeader" )
-        #set( $propType = "Block" )    
-    #elseif ( $prop.type == "integer" )
-        #set( $propType = "ulong" )
-    #elseif( $prop.type == "binary" )
-        #set( $propType = "byte[]" )
-    #elseif( $prop.type == "boolean" )
-        #set( $propType = "bool" )   
-    #elseif ($prop.arrayType && $prop.format == "byte")
-        #set( $propType = "byte[]" )   
-    #elseif ($prop.type == "string" && $prop.format == "byte")
-        #set( $propType = "byte[]" ) 
-    #elseif( $prop.type == "string" || $prop.arrayType == "string" )
-        #set( $propType = "string" )             
-    #elseif( $prop.type == "object" )
-        #set( $propType = "byte[]" )    
-    #elseif( $prop.type == "address" )
-        #set( $propType = "Address" )
-    #elseif( $prop.arrayType  && $prop.arrayType != "")
-        #set( $propType = $prop.arrayType )
-    #elseif( $prop.refType  && $prop.refType != "")
-        #set( $propType = $prop.refType )    
-    #else
-        UNHANDLED TYPE **
-    - name: $!propName
-    - ref: $!prop.refType
-    - type: $!prop.type
-    - array type: $!prop.arrayType
-    - algorand format: $!prop.algorandFormat
-    - format: $!prop.format
-    - prop: $prop
-    $unknown.type ## force a template failure with an unknown type
-    #end
-    #if( $prop.arrayType && $prop.arrayType != "")
-        public System.Collections.Generic.ICollection<$propType> $propName {get;set;} = new System.Collections.ObjectModel.Collection<$propType>();
-    #else
-        public $propType $propName {get;set;}
-    #end
-    #end
-        
-    }
+}
 
 
 }

--- a/dotnet_templates/model.vm
+++ b/dotnet_templates/model.vm
@@ -1,4 +1,5 @@
-namespace Algorand.Algod.Model
+
+namespace $propFile.namespace
 {
 
     using System = global::System;
@@ -10,11 +11,17 @@ namespace Algorand.Algod.Model
         [Newtonsoft.Json.JsonProperty("$prop.propertyName", Required = Newtonsoft.Json.Required.Always)]
         [System.ComponentModel.DataAnnotations.Required]
     #else
-        [Newtonsoft.Json.JsonProperty("top-transactions", Required = Newtonsoft.Json.Required.Default,  NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonProperty("$prop.propertyName", Required = Newtonsoft.Json.Required.Default,  NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
     #end
-    #set( $propName = $str.kebabToUpperCamel($prop.propertyName) )
+    #if (!$prop.algorandLongNameAlias || $prop.algorandLongNameAlias=="")
+        #set( $propName = $str.kebabToUpperCamel($prop.propertyName) )
+    #else
+        #set( $propName = $str.kebabToUpperCamel($prop.algorandLongNameAlias) )
+    #end
     #if ( $prop.algorandFormat == "SignedTransaction" )
         #set( $propType = "SignedTransaction" )
+    #elseif ( $prop.algorandFormat == "Transaction" )
+        #set( $propType = "Transaction" )
     #elseif ( $prop.algorandFormat == "Address" )
         #set( $propType = "Address" )
     #elseif ( $prop.algorandFormat == "TEALProgram" )
@@ -42,12 +49,14 @@ namespace Algorand.Algod.Model
     #elseif( $prop.refType  && $prop.refType != "")
         #set( $propType = $prop.refType )    
     #else
-        UNHANDLED TYPE
+        UNHANDLED TYPE **
+    - name: $!propName
     - ref: $!prop.refType
     - type: $!prop.type
     - array type: $!prop.arrayType
     - algorand format: $!prop.algorandFormat
     - format: $!prop.format
+    - prop: $prop
     $unknown.type ## force a template failure with an unknown type
     #end
     #if( $prop.arrayType && $prop.arrayType != "")

--- a/dotnet_templates/model.vm
+++ b/dotnet_templates/model.vm
@@ -2,6 +2,7 @@
 namespace $propFile.namespace
 {
 
+using Algorand.Algod.Model.Transactions;
 using System = global::System;
 #set($accessibility="public")
 #set($className=$def.name)

--- a/dotnet_templates/model.vm
+++ b/dotnet_templates/model.vm
@@ -1,8 +1,11 @@
 
 namespace $propFile.namespace
 {
+#if($propFile.indexer)
+#else
+    using Algorand.Algod.Model.Transactions;
+#end
 
-using Algorand.Algod.Model.Transactions;
 using System = global::System;
 #set($accessibility="public")
 #set($className=$def.name)
@@ -65,7 +68,7 @@ public partial class $className{
 #elseif ($prop.arrayType && $prop.arrayType=="PendingTransactionResponse")
   #set( $propType = "IReturnableTransaction" )   
 #elseif ($prop.arrayType && $prop.format == "byte")
-    #set( $propType = "byte[]" )   
+    #set( $propType = "byte[]" )
 #elseif ($prop.type == "string" && $prop.format == "byte")
     #set( $propType = "byte[]" ) 
 #elseif( $prop.type == "string" || $prop.arrayType == "string" )
@@ -74,6 +77,8 @@ public partial class $className{
     #set( $propType = "byte[]" )    
 #elseif( $prop.type == "address" )
     #set( $propType = "Address" )
+#elseif( $prop.arrayType  && $prop.arrayType == "integer")
+    #set( $propType = "ulong" )
 #elseif( $prop.arrayType  && $prop.arrayType != "")
     #set( $propType = $prop.arrayType )
 #elseif( $prop.refType  && $prop.refType != "")

--- a/dotnet_templates/model.vm
+++ b/dotnet_templates/model.vm
@@ -22,7 +22,7 @@ namespace Algorand.Algod.Model
     #elseif ( $prop.algorandFormat == "BlockHeader" )
         #set( $propType = "Block" )    
     #elseif ( $prop.type == "integer" )
-        #set( $propType = "uint64" )
+        #set( $propType = "ulong" )
     #elseif( $prop.type == "binary" )
         #set( $propType = "byte[]" )
     #elseif( $prop.type == "boolean" )

--- a/dotnet_templates/model_filename.vm
+++ b/dotnet_templates/model_filename.vm
@@ -1,1 +1,4 @@
+#set( $skip = $propFile.model_skip.split(",") )
+#if ( ! $skip.contains($def.name) )
 ${def.name}.cs
+#end

--- a/dotnet_templates/model_filename.vm
+++ b/dotnet_templates/model_filename.vm
@@ -1,0 +1,1 @@
+${def.name}.cs

--- a/dotnet_templates/model_filename.vm
+++ b/dotnet_templates/model_filename.vm
@@ -1,4 +1,4 @@
 #set( $skip = $propFile.model_skip.split(",") )
 #if ( ! $skip.contains($def.name) )
-${def.name}.cs
+${def.name}.generated.cs
 #end

--- a/dotnet_templates/model_filename.vm
+++ b/dotnet_templates/model_filename.vm
@@ -1,4 +1,13 @@
 #set( $skip = $propFile.model_skip.split(",") )
 #if ( ! $skip.contains($def.name) )
-${def.name}.generated.cs
+#set($fileName=$def.name)
+#if($fileName=="PendingTransactionResponse")
+#set($fileName="ReturnedTransaction")
+#elseif($fileName=="PendingTransactionsResponse")
+#set($fileName="PendingTransactions")
+#elseif($fileName=="BlockResponse")
+#set($fileName="CertifiedBlock")
 #end
+${fileName}.generated.cs
+#end
+

--- a/dotnet_templates/transactions_model_config.properties
+++ b/dotnet_templates/transactions_model_config.properties
@@ -1,0 +1,3 @@
+model_skip=Algorand.Address,Algorand.Algod.Model.AssetParams,Algorand.Digest,Algorand.LogicsigSignature,Algorand.MultisigSignature,Algorand.MultisigSubsig,Algorand.ParticipationPublicKey,Algorand.Signature,Algorand.TEALProgram,Algorand.VRFPublicKey
+model_package=models
+namespace=Algorand.Algod.Model.Transactions

--- a/dotnet_templates/transactions_model_config.properties
+++ b/dotnet_templates/transactions_model_config.properties
@@ -1,3 +1,4 @@
 model_skip=Algorand.Address,Algorand.Algod.Model.AssetParams,Algorand.Digest,Algorand.LogicsigSignature,Algorand.MultisigSignature,Algorand.MultisigSubsig,Algorand.ParticipationPublicKey,Algorand.Signature,Algorand.TEALProgram,Algorand.VRFPublicKey
 model_package=models
 namespace=Algorand.Algod.Model.Transactions
+indexer=false

--- a/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -382,6 +382,12 @@ public class OpenApiParser {
             }
         }
 
+        String parentType=null;
+        if (parentNode.has("allOf") ) {
+            JsonNode refNode=parentNode.get("allOf").get(0).get("$ref");
+            parentType = getTypeNameFromRef(refNode);
+        }
+
         List<TypeDef> properties = new ArrayList<>();
 
         // type: object
@@ -400,7 +406,7 @@ public class OpenApiParser {
             throw new RuntimeException("Unexpected type.");
         }
 
-        publisher.publish(event, new StructDef(className, desc, properties, requiredProperties, mutuallyExclusiveProperties));
+        publisher.publish(event, new StructDef(className, desc, properties, requiredProperties, mutuallyExclusiveProperties,parentType));
         properties.forEach(p -> publisher.publish(Events.NEW_PROPERTY, p));
     }
 

--- a/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -511,7 +511,18 @@ public class OpenApiParser {
                 }
             }
         }
-        this.publisher.publish(Events.NEW_QUERY, new QueryDef(methodName, returnType, path, desc, httpMethod, contentTypes));
+        List<String> tags = new ArrayList<>();
+        if (spec.has("tags") && spec.get("tags").isArray()) {
+            for (JsonNode value : spec.get("tags")) {
+                if (value.isTextual()) {
+                    contentTypes.add(value.asText());
+                } else {
+                    throw new RuntimeException("Unexpected content type: " + value.toString());
+                }
+            }
+        }
+
+        this.publisher.publish(Events.NEW_QUERY, new QueryDef(methodName, returnType, path, desc, httpMethod, contentTypes, tags));
 
         processQueryParams(properties);
 

--- a/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -515,7 +515,7 @@ public class OpenApiParser {
         if (spec.has("tags") && spec.get("tags").isArray()) {
             for (JsonNode value : spec.get("tags")) {
                 if (value.isTextual()) {
-                    contentTypes.add(value.asText());
+                    tags.add(value.asText());
                 } else {
                     throw new RuntimeException("Unexpected content type: " + value.toString());
                 }

--- a/src/main/java/com/algorand/sdkutils/generators/QueryMapperGenerator.java
+++ b/src/main/java/com/algorand/sdkutils/generators/QueryMapperGenerator.java
@@ -251,7 +251,7 @@ public class QueryMapperGenerator extends OpenApiParser {
     public static String getEnumClsssDef (String name, JsonNode node) {
         StringBuffer sb = new StringBuffer();
         String enumName = Tools.getCamelCase(name, true);
-        TypeDef enumType = getEnum(node, name, "", "", "", "", "", "");
+        TypeDef enumType = getEnum(node, name, "", "", "", "", "", "", "");
         sb.append("    public static " + enumType.javaTypeName + " get" + enumName + "(String val) {\n");
         sb.append("        switch(val.toUpperCase()) {\n");
         for (String val : enumType.enumValues) {

--- a/src/main/java/com/algorand/sdkutils/listeners/GoGenerator.java
+++ b/src/main/java/com/algorand/sdkutils/listeners/GoGenerator.java
@@ -311,7 +311,7 @@ public class GoGenerator implements Subscriber {
         this.modelWriter.newModel(
                 new StructDef(this.currentQueryName + "Params",
                         "defines parameters for " + this.currentQueryName,
-                        null, null, null),
+                        null, null, null,null),
                 this.modelsFilePrefix + "filtermodels", "models");
 
         // Add the entry into the applicationClient file

--- a/src/main/java/com/algorand/sdkutils/utils/QueryDef.java
+++ b/src/main/java/com/algorand/sdkutils/utils/QueryDef.java
@@ -79,7 +79,7 @@ public class QueryDef {
         return name;
     }
 
-    public String getApi() {  if (tags == null || tags.isEmpty()) { return "Default"; } else  { return tags.get(0);} }
+    public String getApi() {  if (tags == null || tags.isEmpty()) { return "default"; } else  { return tags.get(0);} }
 
     public List<String> getTags() { return tags; }
 

--- a/src/main/java/com/algorand/sdkutils/utils/QueryDef.java
+++ b/src/main/java/com/algorand/sdkutils/utils/QueryDef.java
@@ -15,17 +15,19 @@ public class QueryDef {
     final public String description;
     final public String method;
     final public List<String> contentType;
+    final public List<String> tags;
     final public List<TypeDef> queryParameters = new ArrayList<>();
     final public List<TypeDef> pathParameters = new ArrayList<>();
     final public List<TypeDef> bodyParameters = new ArrayList<>();
 
-    public QueryDef(String name, String returnType, String path, String description, String method, List<String> contentType) {
+    public QueryDef(String name, String returnType, String path, String description, String method, List<String> contentType, List<String> tags) {
         this.name = name;
         this.returnType = returnType;
         this.path = path;
         this.description = description;
         this.method = method;
         this.contentType = contentType;
+        this.tags = tags;
     }
 
     @Override
@@ -35,7 +37,9 @@ public class QueryDef {
                 + ", return type: " + this.returnType
                 + ", path: " + this.path
                 + ", description: " + this.description
-                + ", method: " + this.method;
+                + ", method: " + this.method
+                + ", api: " + this.getApi();
+
     }
 
     public List<String> getPathParts() {
@@ -74,6 +78,10 @@ public class QueryDef {
     public String getName() {
         return name;
     }
+
+    public String getApi() {  if (tags == null || tags.isEmpty()) { return "Default"; } else  { return tags.get(0);} }
+
+    public List<String> getTags() { return tags; }
 
     public String getReturnType() {
         return returnType;

--- a/src/main/java/com/algorand/sdkutils/utils/StructDef.java
+++ b/src/main/java/com/algorand/sdkutils/utils/StructDef.java
@@ -14,15 +14,17 @@ public class StructDef implements Comparable<StructDef> {
     public List<TypeDef> properties = new ArrayList<>();
     public Set<String> requiredProperties = new HashSet<>();
     public Set<String> mutuallyExclusiveProperties = new HashSet<>();
+    public String parentType;
 
     public StructDef(String name, String aliasOf) {
         this.name = name;
         this.aliasOf = aliasOf;
     }
 
-    public StructDef(String name, String doc, List<TypeDef> properties, Set<String> requiredProperties, Set<String> mutuallyExclusiveProperties) {
+    public StructDef(String name, String doc, List<TypeDef> properties, Set<String> requiredProperties, Set<String> mutuallyExclusiveProperties, String parentType) {
         this.name = name;
         this.doc = doc;
+        this.parentType=parentType;
         if (properties != null) {
             this.properties = properties;
         }
@@ -32,6 +34,8 @@ public class StructDef implements Comparable<StructDef> {
         if (mutuallyExclusiveProperties != null) {
             this.mutuallyExclusiveProperties = mutuallyExclusiveProperties;
         }
+
+
     }
 
     public Set<String> getUniqueTypes() {
@@ -48,6 +52,7 @@ public class StructDef implements Comparable<StructDef> {
     @Override
     public String toString() {
         return "{name: '" + name + "', " +
+                "parent: '" + parentType + "', " +
                 "aliasOf: '" + aliasOf + "', " +
                 "doc: '" + doc + "', " +
                 "properties: " + properties.size() + ", " +
@@ -72,6 +77,10 @@ public class StructDef implements Comparable<StructDef> {
 
     public String getDoc() {
         return doc;
+    }
+
+    public String getParentType() {
+        return parentType;
     }
 
     public List<TypeDef> getProperties() {

--- a/src/main/java/com/algorand/sdkutils/utils/TypeDef.java
+++ b/src/main/java/com/algorand/sdkutils/utils/TypeDef.java
@@ -34,7 +34,8 @@ public class TypeDef {
             String openApiArrayType,
             String openApiFormat,
             String openApiAlgorandFormat,
-            String openApiAlgorandGoFormat) {
+            String openApiAlgorandGoFormat,
+            String openApiAlgorandLongNameAlias) {
         this.javaTypeName = javaTypeName;
         this.rawTypeName = rawTypeName;
         this.type = type;
@@ -47,6 +48,7 @@ public class TypeDef {
         this.openApiFormat = openApiFormat;
         this.openApiAlgorandFormat = openApiAlgorandFormat;
         this.openApiAlgorandGoFormat = openApiAlgorandGoFormat;
+        this.openApiAlgorandLongNameAlias = openApiAlgorandLongNameAlias;
         this.required = required;
     }    
     /**
@@ -77,7 +79,8 @@ public class TypeDef {
             String openApiFormat,
             String openApiAlgorandFormat,
             String openApiAlgorandGoFormat,
-            List<String> enumValues) {
+            List<String> enumValues,
+            String openApiAlgorandLongNameAlias) {
         this.javaTypeName = javaTypeName;
         this.rawTypeName = rawTypeName;
         this.type = type;
@@ -90,6 +93,7 @@ public class TypeDef {
         this.openApiFormat = openApiFormat;
         this.openApiAlgorandFormat = openApiAlgorandFormat;
         this.openApiAlgorandGoFormat = openApiAlgorandGoFormat;
+        this.openApiAlgorandLongNameAlias = openApiAlgorandLongNameAlias;
         this.enumValues = enumValues;
         this.required = required;
     }
@@ -132,6 +136,7 @@ public class TypeDef {
     public String openApiFormat;
     public String openApiAlgorandFormat;
     public String openApiAlgorandGoFormat;
+    public String openApiAlgorandLongNameAlias;
 
     // This field is private because it is sometimes (but usually not) a CSV and it's too easy to accidentally
     // use it the wrong way. Use 'isOfType' to compare against specific types.
@@ -186,6 +191,10 @@ public class TypeDef {
 
     public String getAlgorandFormat() {
         return openApiAlgorandFormat;
+    }
+
+    public String getAlgorandLongNameAlias() {
+        return openApiAlgorandLongNameAlias;
     }
 
     public String getAlgorandGoFormat() {


### PR DESCRIPTION
This trivially small pull request (lol) introduces :

- Templates to generate the .NET SDK AlgoD client
- Introduces Transactions.json (a partial OAS spec for the Transactions class - intended for use by the .NET velocity templates for now, until Algorand decides what to do with their missing Transaction classes ;-) )
- Example command lines for running Generator to update .NET SDK
- Some changes to the Generator source to add Tags, AllOf reference types, dangling references and one or two other bits and bobs

The .NET SDK is taking the approach that Algod.oas2.json is being used as a general modeling language to describe the api and model of the system for documentation, client, and server generation purposes, and in addition it augments that model with the Transaction types. The SDK uses "partial classes" to separate classes into files that are pre-authored and files that are generated. Two files may therefore be used to comprise a single class. The hardcoded utilities in the .NET SDK are attached to concrete Transaction classes (eg: Transaction.Sign(Account)) while the fields are generated using this Generator.

Indexer is separate and will be addressed in a following PR, but nothing much is expected to change: just an additional velocity template for Indexer client and model.
