### PR TITLE
sdk-codegen: update nodejs version

### DIFF
--- a/.github/actions/sdk-codegen/Dockerfile
+++ b/.github/actions/sdk-codegen/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.17.9-bullseye
 ARG GITHUB_CLI_URL="https://github.com/cli/cli/releases/download/v1.8.1/gh_1.8.1_linux_amd64.tar.gz"
 
 # Manually install npm
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y maven openjdk-17-jdk nodejs
 


### PR DESCRIPTION
Updates the sdk codegen github action's Dockerfile to use node version 16.x since 12.x is deprecated.

Currently, codegen runs on js-algorand-sdk  always include `package-lock.json` changes because the older version of node we're using doesn't know how to use the newer lockfile version.

This is fixed by using the newer npm. I ran a test run using my forks to verify that the PR produced by a run does not include package-lock.json changes https://github.com/Eric-Warehime/js-algorand-sdk/pull/6 