### PR TITLE
Go generation improvements for boxes

### DIFF
--- a/go_templates/client.vm
+++ b/go_templates/client.vm
@@ -56,6 +56,12 @@ func MakeClientWithHeaders(address string, apiToken string, headers []*common.He
 
 ## Given a query print the arg list to the function.
 #macro( queryToClientArgs $query )
+#set ( $hasRequiredQueryParams = false )
+#foreach( $p in $query.queryParameters )
+#if ( $p.required )
+#set ( $hasRequiredQueryParams = true )
+#end
+#end
 #set( $sep = "" )
 #foreach( $p in $query.pathParameters )
 $sep#pathParamToArgDef($p)
@@ -65,9 +71,18 @@ $sep#pathParamToArgDef($p)
 $sep#bodyParamToArgDef($p)
 #set( $sep = ", " )
 #end
+#foreach( $p in $query.queryParameters )
+#if ( $p.required )
+$sep#queryParamTypeName($p, true) #queryParamType($p, true)##
+#set( $sep = ", " )
+#end
+#end
 #end
 ## Given a query print the struct initialization.
 #macro( queryToStructInit $query )
+#if ( $hasRequiredQueryParams )
+(##
+#end
 &${queryType}{c: c##
 #foreach( $p in $query.pathParameters )
 , $str.kebabToCamel($p.propertyName): $str.kebabToCamel($p.propertyName)##
@@ -75,7 +90,15 @@ $sep#bodyParamToArgDef($p)
 #foreach( $p in $query.bodyParameters )
 , $str.kebabToCamel($p.propertyName): $str.kebabToCamel($p.propertyName)##
 #end
-}
+}##
+#if ( $hasRequiredQueryParams )
+)##
+#end
+#foreach( $p in $query.queryParameters )
+#if ( $p.required )
+.#queryParamTypeName($p, true)(#queryParamTypeName($p, true))##
+#end
+#end
 #end
 #foreach( $q in $queries )
 #set( $queryType = "$go.queryTypeMapper(${str.capitalize($q.name)})" )

--- a/go_templates/common_macros.vm
+++ b/go_templates/common_macros.vm
@@ -38,9 +38,30 @@ UNHANDLED TYPE
 #end
 #end
 
+#macro ( isBoxNameSpecialCase $queryType $queryParam )
+#if ( ( $queryType == "GetApplicationBoxByName" || $queryType == "LookupApplicationBoxByIDAndName" ) && $queryParam.propertyName == "name" )
+true##
+#else
+false##
+#end
+#end
+
+#macro ( queryParamType $param $setter )
+#if ( "#isBoxNameSpecialCase($queryType, $param)" == "true" )
+[]byte##
+#else
+#oapiToGo($param, $setter)##
+#end
+#end
+
 ## Name of function to set a parameter.
-#macro ( queryParamTypeName $param )
-$go.queryParamTypeNameMapper($queryType, $str.kebabToUpperCamel($param.propertyName).replace("Id", "ID"))##
+#macro ( queryParamTypeName $param $setter )
+#if ( $param.required && $setter )
+#set ( $propertyName = "$str.kebabToCamel($param.propertyName)" )
+#else
+#set ( $propertyName = "$str.kebabToUpperCamel($param.propertyName)" )
+#end
+$go.queryParamTypeNameMapper($queryType, $propertyName.replace("Id", "ID"))##
 #end
 
 #macro ( pathParamToArgDef $param )

--- a/go_templates/query.vm
+++ b/go_templates/query.vm
@@ -15,7 +15,7 @@ package $propFile.query_package;
 import (
   "context"
 #foreach( $qp in $q.queryParameters)
-#if( $qp.algorandFormat == "base64" )
+#if( $qp.algorandFormat == "base64" || "#isBoxNameSpecialCase($queryType, $qp)" == "true" )
   "encoding/base64"
 #break
 #end
@@ -53,13 +53,14 @@ import (
 // ${paramsType} contains all of the query parameters for url serialization.
 type ${paramsType} struct {
 #foreach( $qp in $q.queryParameters)
-#if ( "#queryParamTypeName($qp)" != "" )
+#set ( $qpName = "#queryParamTypeName($qp, false)" )
+#if ( $qpName != "" )
 
-  // $str.formatDoc("#queryParamTypeName($qp) ${str.uncapitalize($qp.doc)}", "  // ")
+  // $str.formatDoc("$qpName ${str.uncapitalize($qp.doc)}", "  // ")
   #if ( $qp.arrayType == "string" )
-    #queryParamTypeName($qp) []string `url:"$qp.propertyName,omitempty,comma"`
+    $qpName []string `url:"$qp.propertyName,omitempty,comma"`
   #else
-    #queryParamTypeName($qp) #oapiToGo($qp, false) `url:"$qp.propertyName,omitempty"`
+    $qpName #oapiToGo($qp, false) `url:"$qp.propertyName,omitempty"`
   #end
 #end
 #end
@@ -86,30 +87,34 @@ type $queryType struct {
 #end
 }
 #foreach( $qp in $q.queryParameters)
-#if ( "#queryParamTypeName($qp)" != "" && "#queryParamTypeName($qp)" != "Format")## No setter for Format
+#set ( $qpFieldName = "#queryParamTypeName($qp, false)" )
+#set ( $qpName = "#queryParamTypeName($qp, true)" )
+#if ( $qpName != "" && $qpName != "Format")## No setter for Format
 
 ## Special handling for date fields.
 #if( $qp.algorandFormat == "RFC3339 String" )
-// $str.formatDoc("#queryParamTypeName($qp)String ${str.uncapitalize($qp.doc)}", "// ")
-func (s *$queryType) #queryParamTypeName($qp)String(#queryParamTypeName($qp) #oapiToGo($qp, false)) *$queryType {
-  s.p.#queryParamTypeName($qp) = #queryParamTypeName($qp)
+// $str.formatDoc("${qpName}String ${str.uncapitalize($qp.doc)}", "// ")
+func (s *$queryType) ${qpName}String($qpName #oapiToGo($qp, false)) *$queryType {
+  s.p.$qpFieldName = $qpName
 
   return s
 }
 
-// $str.formatDoc("#queryParamTypeName($qp) ${str.uncapitalize($qp.doc)}", "// ")
-func (s *$queryType) #queryParamTypeName($qp)(#queryParamTypeName($qp) time.Time) *$queryType {
-  #queryParamTypeName($qp)Str := #queryParamTypeName($qp).Format(time.RFC3339)
+// $str.formatDoc("$qpName ${str.uncapitalize($qp.doc)}", "// ")
+func (s *$queryType) ${qpName}($qpName time.Time) *$queryType {
+  ${qpName}Str := ${qpName}.Format(time.RFC3339)
 
-  return s.#queryParamTypeName($qp)String(#queryParamTypeName($qp)Str)
+  return s.${qpName}String(${qpName}Str)
 }
 #else
-// $str.formatDoc("#queryParamTypeName($qp) ${str.uncapitalize($qp.doc)}", "// ")
-func (s *$queryType) #queryParamTypeName($qp)(#queryParamTypeName($qp) #oapiToGo($qp, true)) *$queryType {
-#if( $qp.algorandFormat == "base64" )
-  s.p.#queryParamTypeName($qp) = base64.StdEncoding.EncodeToString(#queryParamTypeName($qp))
+// $str.formatDoc("$qpName ${str.uncapitalize($qp.doc)}", "// ")
+func (s *$queryType) ${qpName}($qpName #queryParamType($qp, true)) *$queryType {
+#if ( "#isBoxNameSpecialCase($queryType, $qp)" == "true" )
+  s.p.$qpFieldName = "b64:" + base64.StdEncoding.EncodeToString($qpName)
+#elseif( $qp.algorandFormat == "base64" )
+  s.p.$qpFieldName = base64.StdEncoding.EncodeToString($qpName)
 #elseif ( $qp.type == "integer" || $qp.type == "string" || $qp.type == "boolean" || $qp.arrayType )
-  s.p.#queryParamTypeName($qp) = #queryParamTypeName($qp)
+  s.p.$qpFieldName = $qpName
 #else
 UNHANDLED TYPE
 - ref: $!qp.refType


### PR DESCRIPTION
This PR makes the following changes to Go code generation:
* Required query parameters are now treated differently. Instead of using the builder pattern to set these properties, they must be passed in during the creation of the query object. Additionally, the builder function used to set these properties is now private, so they cannot be modified after creation.
  * Before the new box endpoints, we did not have any required query parameters, so this doesn't change our existing code in any way.
  * Here's an example:
```go
//  --- Before this PR ---

// definition
func (c *Client) GetApplicationBoxByName(applicationId uint64) *GetApplicationBoxByName {
	return &GetApplicationBoxByName{c: c, applicationId: applicationId}
)

// usage
client.GetApplicationBoxByName(applicationId).Name(name).Do(context.Background())

// --- After this PR ---

// definition
func (c *Client) GetApplicationBoxByName(applicationId uint64, name []byte) *GetApplicationBoxByName {
	return (&GetApplicationBoxByName{c: c, applicationId: applicationId}).name(name)
)

// usage
client.GetApplicationBoxByName(applicationId, name).Do(context.Background())
```
  * Algod and indexer both have a `/v2/applications/{appId}/box` endpoint which is nonstandard. This endpoint has a required query parameter `name` that follows a special convention. This `name` parameter is typed as a string, but it's really meant to express arbitrary byte arrays. I've added a special case for this specific parameter such that SDK users can provide a byte slice which is automatically converted to a properly formatted string.
    * Here's an example:
```go
//  --- Before this PR ---

// definition
func (s *GetApplicationBoxByName) name(name string) *GetApplicationBoxByName {
	s.p.Name = Name

	return s
}

// usage
var boxName []byte // somehow populated
boxNameStr := encoding.EncodeBytesForBoxQuery(boxName)
client.GetApplicationBoxByName(applicationId, boxNameStr).Do(context.Background())

// --- After this PR ---

// definition
func (s *GetApplicationBoxByName) name(name []byte) *GetApplicationBoxByName {
	s.p.Name = "b64:" + base64.StdEncoding.EncodeToString(name)

	return s
}

// usage
var boxName []byte // somehow populated
client.GetApplicationBoxByName(applicationId, boxName).Do(context.Background())
```

While the changes in these PR are not technically necessary, they do improve the ergonomics for end users.

I have not attempted to bring similar changes to the Java SDK because its client generation does not appear to use templates, so changing it seems more involved and likely isn't worth it at this time.