### PR TITLE
Add disassemble post query to Go SDK

### DIFF
--- a/go_templates/query.vm
+++ b/go_templates/query.vm
@@ -251,6 +251,11 @@ func (s *TealDryrun) Do(ctx context.Context, headers ...*common.Header) (respons
   err = s.c.post(ctx, &response, "/v2/teal/dryrun", nil, headers, msgpack.Encode(&s.request))
   return
 }
+#elseif( $queryType == "TealDisassemble" )## TODO: "post" can be generated, there is nothing special here.
+func (s *TealDisassemble) Do(ctx context.Context, headers ...*common.Header) (response models.DisassembleResponse, err error) {
+  err = s.c.post(ctx, &response, "/v2/teal/disassemble", nil, headers, s.source)
+  return
+}
 #else## finally... machine generate the rest
 func (s *${queryType}) Do(ctx context.Context, headers ...*common.Header) (response $returnType, err error) {
   err = s.c.get(ctx, &response, $processedPath, $queryArg, headers)


### PR DESCRIPTION
Overrides the `TealDisassemble` query in `query.vm` for the Go SDK.

This is part of a fix in the Go SDK where the disassemble endpoint was generated as a GET query instead of a POST query: https://github.com/algorand/go-algorand-sdk/pull/436