### PR TITLE
Fix parsing bugs and expand `private` filtering

### DIFF
--- a/go_templates/client.vm
+++ b/go_templates/client.vm
@@ -17,6 +17,11 @@ const authHeader = "$propFile.auth_header"
 
 type Client common.Client
 
+// delete performs a DELETE request to the specific path against the server, assumes JSON response
+func (c *Client) delete(ctx context.Context, response interface{}, path string, body interface{}, headers []*common.Header) error {
+	return (*common.Client)(c).Delete(ctx, response, path, body, headers)
+}
+
 // get performs a GET request to the specific path against the server, assumes JSON response
 func (c *Client) get(ctx context.Context, response interface{}, path string, body interface{}, headers []*common.Header) error {
        return (*common.Client)(c).Get(ctx, response, path, body, headers)

--- a/go_templates/query.vm
+++ b/go_templates/query.vm
@@ -256,6 +256,16 @@ func (s *TealDisassemble) Do(ctx context.Context, headers ...*common.Header) (re
   err = s.c.post(ctx, &response, "/v2/teal/disassemble", nil, headers, s.source)
   return
 }
+#elseif( $queryType == "UnsetSyncRound" )## TODO: "delete" can be generated, there is nothing special here.
+func (s *${queryType}) Do(ctx context.Context, headers ...*common.Header) (response $returnType, err error) {
+  err = s.c.delete(ctx, &response, $processedPath, nil, headers)
+  return
+}
+#elseif( $queryType == "SetSyncRound" )## TODO: "post" can be generated, there is nothing special here.
+func (s *${queryType}) Do(ctx context.Context, headers ...*common.Header) (response $returnType, err error) {
+  err = s.c.post(ctx, &response, $processedPath, nil, headers, nil)
+  return
+}
 #else## finally... machine generate the rest
 func (s *${queryType}) Do(ctx context.Context, headers ...*common.Header) (response $returnType, err error) {
   err = s.c.get(ctx, &response, $processedPath, $queryArg, headers)

--- a/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -314,28 +314,44 @@ public class OpenApiParser {
     }
 
     // Returns an iterator in sorted order of the parameters (json nodes).
-    Iterator<Entry<String, JsonNode>> getSortedParameters(JsonNode properties) {
+    Iterator<Entry<String, JsonNode>> getSortedParameters(JsonNode pathParams, JsonNode methodParams) {
         TreeMap<String, JsonNode> tm = new TreeMap<String, JsonNode>();
-        if (properties == null) {
-            return tm.entrySet().iterator();
+        List<JsonNode> paramNodes = new ArrayList<>();
+
+        if (pathParams != null) {
+            if (!pathParams.isArray()) {
+                throw new IllegalArgumentException("Expected node to be an array, but got: " + pathParams.getNodeType());
+            }
+
+            Iterator<JsonNode> elements = pathParams.elements();
+            while (elements.hasNext()) {
+                paramNodes.add(elements.next());
+            }
         }
 
-        if (properties.isArray()) {
-            ArrayNode jsonArrayNode = (ArrayNode) properties;
-            for (int i = 0; i < jsonArrayNode.size(); i++) {
-                JsonNode node = jsonArrayNode.get(i);
-                JsonNode typeNode = null;
-                if (node.get("$ref") != null) {
-                    typeNode = this.getFromRef(node.get("$ref").asText());
-                } else {
-                    typeNode = node;
-                }
-                tm.put(typeNode.get("name").asText(), typeNode);
+        if (methodParams != null) {
+            if (!methodParams.isArray()) {
+                throw new IllegalArgumentException("Expected node to be an array, but got: " + methodParams.getNodeType());
             }
-            Iterator<Entry<String, JsonNode>>sortedParams = tm.entrySet().iterator();
-            return sortedParams;
+
+            Iterator<JsonNode> elements = methodParams.elements();
+            while (elements.hasNext()) {
+                paramNodes.add(elements.next());
+            }
         }
-        return null;
+
+        for (JsonNode node : paramNodes) {
+            JsonNode typeNode = null;
+            if (node.get("$ref") != null) {
+                typeNode = this.getFromRef(node.get("$ref").asText());
+            } else {
+                typeNode = node;
+            }
+            tm.put(typeNode.get("name").asText(), typeNode);
+        }
+
+        Iterator<Entry<String, JsonNode>> sortedParams = tm.entrySet().iterator();
+        return sortedParams;
     }
 
     // Extract a list of required properties from a parent node
@@ -485,16 +501,8 @@ public class OpenApiParser {
 
     // Write the class of a path expression
     // This is the root method for preparing the complete class
-    void writeQueryClass(
-            JsonNode spec,
-            String path) throws IOException {
-
-        String httpMethod;
-        Iterator<String> fields = spec.fieldNames();
-        httpMethod = fields.next();
-        spec = spec.get(httpMethod);
-
-        String className = spec.get("operationId").asText();
+    void writeQueryClass(String path, JsonNode pathParams, String httpMethod, JsonNode spec, String operationId) throws IOException {
+        String className = operationId;
 
         /*
          * TODO: this is a bug: function name should start with a small letter.
@@ -532,7 +540,7 @@ public class OpenApiParser {
         logger.debug("Generating ... {}", className);
         Iterator<Entry<String, JsonNode>> properties = null;
         if ( paramNode != null) {
-            properties = getSortedParameters(paramNode);
+            properties = getSortedParameters(pathParams, paramNode);
         }
 
         List<String> contentTypes = new ArrayList<>();
@@ -568,6 +576,22 @@ public class OpenApiParser {
         JsonNode schemas = root.get("components") !=
                 null ? root.get("components").get("schemas") : root.get("definitions");
                 for (Map.Entry<String, JsonNode> cls : getSortedSchema(schemas).entrySet()) {
+                    JsonNode tags = cls.getValue().get("tags");
+                    if (tags != null) {
+                        boolean isPrivate = false;
+                        Iterator<JsonNode> tagIter = tags.elements();
+                        while (tagIter.hasNext()) {
+                            JsonNode tag = tagIter.next();
+                            if (tag.asText().equals("private")) {
+                                isPrivate = true;
+                                break;
+                            }
+                        }
+                        if (isPrivate) {
+                            continue;
+                        }
+                    }
+
                     String desc = null;
                     if (cls.getValue().get("description") != null) {
                         desc = cls.getValue().get("description").asText();
@@ -582,6 +606,7 @@ public class OpenApiParser {
                         // If it has no properties, no class is needed for this type.
                         continue;
                     }
+
                     String className = Tools.getCamelCase(cls.getKey(), true);
                     if (!filterList.isEmpty() && filterList.contains(className)) {
                         continue;
@@ -600,6 +625,23 @@ public class OpenApiParser {
                 Iterator<Entry<String, JsonNode>> returnTypes = returns.fields();
                 while (returnTypes.hasNext()) {
                     Entry<String, JsonNode> rtype = returnTypes.next();
+
+                    JsonNode tags = rtype.getValue().get("tags");
+                    if (tags != null) {
+                        boolean isPrivate = false;
+                        Iterator<JsonNode> tagIter = tags.elements();
+                        while (tagIter.hasNext()) {
+                            JsonNode tag = tagIter.next();
+                            if (tag.asText().equals("private")) {
+                                isPrivate = true;
+                                break;
+                            }
+                        }
+                        if (isPrivate) {
+                            continue;
+                        }
+                    }
+
                     JsonNode rSchema = null;
                     if (rtype.getValue().has("content")) {
                         rSchema = rtype.getValue().get("content").get("application/json").get("schema");
@@ -639,17 +681,43 @@ public class OpenApiParser {
         Iterator<Entry<String, JsonNode>> pathIter = paths.fields();
         while (pathIter.hasNext()) {
             Entry<String, JsonNode> path = pathIter.next();
-            JsonNode privateTag = path.getValue().get("post") !=
-                    null ? path.getValue().get("post").get("tags") : null;
-                    if (privateTag != null && privateTag.elements().next().asText().equals("private")) {
+            JsonNode pathParams = path.getValue().get("parameters");
+
+            Iterator<Entry<String, JsonNode>> fieldIter = path.getValue().fields();
+            while (fieldIter.hasNext()) {
+                Entry<String, JsonNode> field = fieldIter.next();
+
+                if (field.getKey().equals("parameters")) {
+                    continue;
+                }
+                
+                JsonNode tags = field.getValue().get("tags");
+                if (tags != null) {
+                    boolean isPrivate = false;
+                    Iterator<JsonNode> tagIter = tags.elements();
+                    while (tagIter.hasNext()) {
+                        JsonNode tag = tagIter.next();
+                        if (tag.asText().equals("private")) {
+                            isPrivate = true;
+                            break;
+                        }
+                    }
+                    if (isPrivate) {
                         continue;
                     }
-                    String className = Tools.getCamelCase(
-                            path.getValue().get(path.getValue().fieldNames().next()).get("operationId").asText(), true);
-                    if (!filterList.isEmpty() && filterList.contains(className)) {
-                        continue;
-                    }
-                    writeQueryClass(path.getValue(), path.getKey());
+                }
+
+                JsonNode operationId = field.getValue().get("operationId");
+                if (operationId == null) {
+                    throw new IllegalArgumentException(String.format("Path %s with method %s has no operationId", path.getKey(), field.getKey()));
+                }
+                String className = Tools.getCamelCase(operationId.asText(), true);
+                if (!filterList.isEmpty() && filterList.contains(className)) {
+                    continue;
+                }
+
+                writeQueryClass(path.getKey(), pathParams, field.getKey(), field.getValue(), operationId.asText());
+            }
         }
     }
 

--- a/src/main/java/com/algorand/sdkutils/generators/QueryMapperGenerator.java
+++ b/src/main/java/com/algorand/sdkutils/generators/QueryMapperGenerator.java
@@ -130,7 +130,7 @@ public class QueryMapperGenerator extends OpenApiParser {
                 "            switch (property) {\n");
 
         JsonNode paramNode = path.getValue().findValue("parameters");
-        Iterator<Entry<String, JsonNode>> properties = getSortedParameters(paramNode);
+        Iterator<Entry<String, JsonNode>> properties = getSortedParameters(null, paramNode);
 
         // The parameters in the path are directly passed to the constructor.
         // The method with have in order arguments each assigned to the parameter in order. 

--- a/src/main/java/com/algorand/sdkutils/generators/TemplateGenerator.java
+++ b/src/main/java/com/algorand/sdkutils/generators/TemplateGenerator.java
@@ -46,7 +46,7 @@ public class TemplateGenerator extends OpenApiParser {
             notes.append(pathString+"\n");
 
             JsonNode paramNode = path.getValue().findValue("parameters");
-            Iterator<Entry<String, JsonNode>> properties = getSortedParameters(paramNode);
+            Iterator<Entry<String, JsonNode>> properties = getSortedParameters(null, paramNode);
             bw.append(pathString + ", ");
             while (properties.hasNext()) {
                 Entry<String, JsonNode> parameter = properties.next();

--- a/src/test/java/com/algorand/sdkutils/generators/OpenApiParserTest.java
+++ b/src/test/java/com/algorand/sdkutils/generators/OpenApiParserTest.java
@@ -54,16 +54,43 @@ class OpenApiParserTest {
                 .extracting("name")
                 .containsAll(expectedStructs);
 
-        // 'onEvent(evt)' - called 20 times, once for each END_QUERY/END_MODEL.
-        verify(subscriber, times(20))
+        // 'onEvent(evt)' - called 26 times, once for each END_QUERY (20) and END_MODEL (6).
+        verify(subscriber, times(26))
                 .onEvent(any());
 
         // 'onEvent(evt, []String)` - called 14 times, once for each NEW_QUERY.
-        verify(subscriber, times(14))
-                .onEvent(any(), any(QueryDef.class));
+        List<String> expectedQueries = ImmutableList.of(
+                "POST:/pet/{petId}/uploadImage",
+                "POST:/pet",
+                "PUT:/pet",
+                "GET:/pet/findByStatus",
+                "GET:/pet/findByTags",
+                "GET:/pet/{petId}",
+                "POST:/pet/{petId}",
+                "DELETE:/pet/{petId}",
+                "POST:/store/order",
+                "GET:/store/order/{orderId}",
+                "DELETE:/store/order/{orderId}",
+                "GET:/store/inventory",
+                "POST:/user/createWithArray",
+                "POST:/user/createWithList",
+                "GET:/user/{username}",
+                "PUT:/user/{username}",
+                "DELETE:/user/{username}",
+                "GET:/user/login",
+                "GET:/user/logout",
+                "POST:/user"
+        );
+        ArgumentCaptor<QueryDef> queryDefArgumentCaptor = ArgumentCaptor.forClass(QueryDef.class);
+        verify(subscriber, times(expectedQueries.size()))
+                .onEvent(any(), queryDefArgumentCaptor.capture());
+
+        assertThat(queryDefArgumentCaptor.getAllValues())
+                .extracting(queryDef -> queryDef.method.toUpperCase() + ":" + queryDef.path)
+                .containsAll(expectedQueries);
 
         // Property, Path param, Query param, Body
-        verify(subscriber, times(42))
+        verify(subscriber, times(52))
                 .onEvent(any(), any(TypeDef.class));
     }
 }


### PR DESCRIPTION
This PR fixes a few bugs in the OpenAPI parser. They are:

* Only 1 request type (e.g. POST, GET) per route was being parsed.
  * Algod happens to not have any non-private routes with multiple request types, so this behavior was not noticed until now.
* Only POST requests were being checked for the `private` tag, which the generator uses to decide if an operation should be ignored.
* Types with the `private` tag were not being ignored.
  * It's hard to classify this as a bug vs an expansion of filtering that was only in place for routes before. Since algod annotates some definitions with a `private` tag, I think it makes sense to also filter definitions and response types like this as well.

This PR would fix #20