### PR TITLE
Ignore experimental tags

### DIFF
--- a/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -458,6 +458,22 @@ public class OpenApiParser {
         return true;
     }
 
+    /**
+     * Check whether we should ignore a route, response, or definition based on the value of one of
+     * its tags.
+     * 
+     * You should call this method to check every tag related to a node. If this returns true for
+     * any tag, that node should be ignored.
+     * @param tagText The String value of its tag
+     * @return Whether the object should be ignored based on this tag
+     */
+    static boolean shouldIgnoreTag(String tagText) {
+        if (tagText.equals("private") || tagText.equals("experimental")) {
+            return true;
+        }
+        return false;
+    }
+
     // Query parameters need be in builder methods.
     // processQueryParameters do all the processing of the parameters.
     void processQueryParams(
@@ -582,8 +598,7 @@ public class OpenApiParser {
                         Iterator<JsonNode> tagIter = tags.elements();
                         while (tagIter.hasNext()) {
                             JsonNode tag = tagIter.next();
-                            String tagText = tag.asText();
-                            if (tagText.equals("private") || tagText.equals("experimental")) {
+                            if (shouldIgnoreTag(tag.asText())) {
                                 ignore = true;
                                 break;
                             }
@@ -633,8 +648,7 @@ public class OpenApiParser {
                         Iterator<JsonNode> tagIter = tags.elements();
                         while (tagIter.hasNext()) {
                             JsonNode tag = tagIter.next();
-                            String tagText = tag.asText();
-                            if (tagText.equals("private") || tagText.equals("experimental")) {
+                            if (shouldIgnoreTag(tag.asText())) {
                                 ignore = true;
                                 break;
                             }
@@ -699,8 +713,7 @@ public class OpenApiParser {
                     Iterator<JsonNode> tagIter = tags.elements();
                     while (tagIter.hasNext()) {
                         JsonNode tag = tagIter.next();
-                        String tagText = tag.asText();
-                        if (tagText.equals("private") || tagText.equals("experimental")) {
+                        if (shouldIgnoreTag(tag.asText())) {
                             ignore = true;
                             break;
                         }

--- a/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -578,16 +578,17 @@ public class OpenApiParser {
                 for (Map.Entry<String, JsonNode> cls : getSortedSchema(schemas).entrySet()) {
                     JsonNode tags = cls.getValue().get("tags");
                     if (tags != null) {
-                        boolean isPrivate = false;
+                        boolean ignore = false;
                         Iterator<JsonNode> tagIter = tags.elements();
                         while (tagIter.hasNext()) {
                             JsonNode tag = tagIter.next();
-                            if (tag.asText().equals("private")) {
-                                isPrivate = true;
+                            String tagText = tag.asText();
+                            if (tagText.equals("private") || tagText.equals("experimental")) {
+                                ignore = true;
                                 break;
                             }
                         }
-                        if (isPrivate) {
+                        if (ignore) {
                             continue;
                         }
                     }
@@ -628,16 +629,17 @@ public class OpenApiParser {
 
                     JsonNode tags = rtype.getValue().get("tags");
                     if (tags != null) {
-                        boolean isPrivate = false;
+                        boolean ignore = false;
                         Iterator<JsonNode> tagIter = tags.elements();
                         while (tagIter.hasNext()) {
                             JsonNode tag = tagIter.next();
-                            if (tag.asText().equals("private")) {
-                                isPrivate = true;
+                            String tagText = tag.asText();
+                            if (tagText.equals("private") || tagText.equals("experimental")) {
+                                ignore = true;
                                 break;
                             }
                         }
-                        if (isPrivate) {
+                        if (ignore) {
                             continue;
                         }
                     }
@@ -697,7 +699,8 @@ public class OpenApiParser {
                     Iterator<JsonNode> tagIter = tags.elements();
                     while (tagIter.hasNext()) {
                         JsonNode tag = tagIter.next();
-                        if (tag.asText().equals("private")) {
+                        String tagText = tag.asText();
+                        if (tagText.equals("private") || tagText.equals("experimental")) {
                             isPrivate = true;
                             break;
                         }

--- a/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
+++ b/src/main/java/com/algorand/sdkutils/generators/OpenApiParser.java
@@ -695,17 +695,17 @@ public class OpenApiParser {
                 
                 JsonNode tags = field.getValue().get("tags");
                 if (tags != null) {
-                    boolean isPrivate = false;
+                    boolean ignore = false;
                     Iterator<JsonNode> tagIter = tags.elements();
                     while (tagIter.hasNext()) {
                         JsonNode tag = tagIter.next();
                         String tagText = tag.asText();
                         if (tagText.equals("private") || tagText.equals("experimental")) {
-                            isPrivate = true;
+                            ignore = true;
                             break;
                         }
                     }
-                    if (isPrivate) {
+                    if (ignore) {
                         continue;
                     }
                 }


### PR DESCRIPTION
This PR configures the generator to ignore models/routes tagged with `experimental`, in addition to `private`.

The reason to do this is because we no longer wish to use the `private` tag with experimental routes, since for algod that tag implies admin authentication should be used instead of the normal token.