### PR TITLE
Build and test with CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 14
+    - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: '14'
+        java-version: '11'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,12 +21,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: maven
+    - name: Print Java Version
+      run: java --version
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,8 +21,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Print Java Version
-      run: java --version
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '16'
+        distribution: 'temurin'
+        cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,35 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 14
+      uses: actions/setup-java@v3
+      with:
+        java-version: '14'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
This adds a github actions job to make sure the project compiles and passes tests on commits/PRs.

The file was generated by the "Java with Maven" github actions template. The only change I made was to increase the JVM version from 11 to 16. I believe the `pom.xml` wants version 14, and while that's unfortunately not installable for some reason with [the `actions/setup-java` action](https://github.com/actions/setup-java#supported-version-syntax), 16 seems to work.