### PR TITLE
Add clean command for typescript models

### DIFF
--- a/scripts/generate_typescript.sh
+++ b/scripts/generate_typescript.sh
@@ -77,6 +77,9 @@ if [ -z $SKIP_BUILD ]; then
   mvn package
 fi
 
+# Clean previously (stale) generated files before regenerating them.
+find $SDK_DIR/src/client/v2/algod/models/* $SDK_DIR/src/client/v2/indexer/models/* -delete
+
 java -jar target/generator-*-jar-with-dependencies.jar \
       template \
       -s "$ALGOD_SPEC" \


### PR DESCRIPTION
We don't need to clean anything for the JS SDK because there is only one file in `models/` that is regenerated at this point, but this PR standardizes the workflow and protects against future generation that might happen.