### PR TITLE
Add buffer import to TS template

### DIFF
--- a/typescript_templates/model.vm
+++ b/typescript_templates/model.vm
@@ -129,6 +129,7 @@ typeof $value !== 'undefined' ? $assignment : undefined##
  */
 
 /* eslint-disable no-use-before-define */
+import { Buffer } from 'buffer';
 import BaseModel from '../../basemodel';
 #if ( $propFile.indexer == "false" )
 import { EncodedSignedTransaction } from '../../../../types/transactions/encoded';


### PR DESCRIPTION
This PR adds a line to the TypeScript template to generate a `Buffer` import. The rationale for doing this is outlined in this JS SDK PR: https://github.com/algorand/js-algorand-sdk/pull/733. 

PR here shows that the `Buffer` import is generated for algod and indexer: https://github.com/algorand/js-algorand-sdk/compare/simulate-endpoint-generate