### PR TITLE
Fix JS github action logic

### DIFF
--- a/.github/actions/sdk-codegen/Dockerfile
+++ b/.github/actions/sdk-codegen/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.17.9-bullseye
 ARG GITHUB_CLI_URL="https://github.com/cli/cli/releases/download/v1.8.1/gh_1.8.1_linux_amd64.tar.gz"
 
 # Manually install npm
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y maven openjdk-17-jdk nodejs
 

--- a/.github/actions/sdk-codegen/entrypoint.sh
+++ b/.github/actions/sdk-codegen/entrypoint.sh
@@ -36,10 +36,17 @@ function generate_js {
     -s "$ALGOD_SPEC" \
     -t "$TEMPLATE_DIR" \
     -m "$JS_SDK_DIR/src/client/v2/algod/models" \
-    -p "$TEMPLATE_DIR/common_config.properties,$TEMPLATE_DIR/parameter_order_overrides.properties"
+    -p "$TEMPLATE_DIR/algod_config.properties,$TEMPLATE_DIR/parameter_order_overrides.properties"
+
+  # Generate indexer.
+  $TEMPLATE \
+    -s "$INDEXER_SPEC" \
+    -t "$TEMPLATE_DIR" \
+    -m "$JS_SDK_DIR/src/client/v2/indexer/models" \
+    -p "$TEMPLATE_DIR/indexer_config.properties"
 
   pushd $JS_SDK_DIR
-  npm install
+  npm ci
   make format
   /publish.sh
 }

--- a/.github/actions/sdk-codegen/entrypoint.sh
+++ b/.github/actions/sdk-codegen/entrypoint.sh
@@ -31,6 +31,10 @@ function generate_js {
   TEMPLATE_DIR=$GENERATOR_DIR/typescript_templates
   export GH_REPO=$JS_SDK_REPO
   git clone --depth 1 https://github.com/algorand/js-algorand-sdk $JS_SDK_DIR
+
+  # Clean previously (stale) generated files before regenerating them.
+  find $JS_SDK_DIR/src/client/v2/algod/models/* $JS_SDK_DIR/src/client/v2/indexer/models/* -delete
+
   # Generate algod.
   $TEMPLATE \
     -s "$ALGOD_SPEC" \
@@ -56,6 +60,16 @@ function generate_go {
   TEMPLATE_DIR=$GENERATOR_DIR/go_templates
   export GH_REPO=$GO_SDK_REPO
   git clone https://github.com/algorand/go-algorand-sdk $GO_SDK_DIR
+  
+  # Clean previously (stale) generated files before regenerating them.
+  # Some files are hand-written instead of generated, so preserve those files here.
+  find $GO_SDK_DIR/client/v2/common/models/* $GO_SDK_DIR/client/v2/algod/* $GO_SDK_DIR/client/v2/indexer/* \
+    \! -name 'account_error_response.go' \
+    \! -name 'blockRaw.go' \
+    \! -name 'dryrun.go' \
+    \! -name 'shim.go' \
+    -delete
+
   # Generate algod.
   $TEMPLATE \
     -s $ALGOD_SPEC \
@@ -83,6 +97,14 @@ function generate_java {
   JAVA_SDK_DIR=/clones/java-algorand-sdk
   export GH_REPO=$JAVA_SDK_REPO
   git clone https://github.com/algorand/java-algorand-sdk $JAVA_SDK_DIR
+
+  # Clean previously (stale) generated files before regenerating them.
+  # Hand-written files are confined to algosdk/v2/client/common,
+  # except AlgodClient, which will be re-generated according to the specs. 
+  find $JAVA_SDK_DIR/src/main/java/com/algorand/algosdk/v2/client/model/* \
+      $JAVA_SDK_DIR/src/main/java/com/algorand/algosdk/v2/client/algod/* \
+      $JAVA_SDK_DIR/src/main/java/com/algorand/algosdk/v2/client/indexer/* \
+      -delete
 
  $GENERATOR \
     java \


### PR DESCRIPTION
For a while, the github action for JS generation has been failing. Example: https://github.com/algorand/js-algorand-sdk/actions/runs/7241641297/job/19725977258

The problem was the logic to invoke the generator in `.github/actions/sdk-codegen/entrypoint.sh` became outdated and out of sync with `scripts/generate_typescript.sh`, shown below: https://github.com/algorand/generator/blob/88668a4cabad2a7c4ca6f8426c1c55b091231939/scripts/generate_typescript.sh#L80-L95

Additionally, I've updated the every languages' script to include the new step of cleaning directories before generation, which is currently present in their `scripts/generate_x.sh` files.

Perhaps there's a smarter way to deduplicate this logic, but I just wanted to fix the problem for now.