### PR TITLE
build: fix PR creation

### DIFF
--- a/.github/actions/sdk-codegen/publish.sh
+++ b/.github/actions/sdk-codegen/publish.sh
@@ -108,4 +108,5 @@ gh pr create \
   --repo $GH_REPO \
   $BASE_ARG_PAIR \
   --title "Regenerate code with the latest specification file ($PR_ID)" \
+  --head $(git branch --show-current) \
   --body "$PR_BODY"


### PR DESCRIPTION
## Summary

Auto generation action fails with `aborted: you must first push the current branch to a remote, or use the --head flag`.
See for details https://github.com/cli/cli/issues/6485