### PR TITLE
go: Include the `model`package if SimulateTransaction is present

### DIFF
--- a/go_templates/client.vm
+++ b/go_templates/client.vm
@@ -8,7 +8,7 @@ import (
   "github.com/algorand/go-algorand-sdk/v2/client/v2/common"
 #foreach( $q in $queries )
 ## TODO: Something like: $str.matches("#oapiToGo($qp)", "model\..*")
-#if ( "$go.queryTypeMapper(${str.capitalize($q.name)})" == "TealDryrun" )
+#if ( "$go.queryTypeMapper(${str.capitalize($q.name)})" == "SimulateTransaction" )
   "github.com/algorand/go-algorand-sdk/v2/client/v2/common/models"
 #end
 #end


### PR DESCRIPTION
We removed `TealDryRun` recently but `SimulateTransaction` still requires the package for the generated file to work as expected (meaning: compile w/o errors).